### PR TITLE
pyisolate 0.10.2

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -51,17 +51,25 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  smoke-test:
-    name: Smoke Test Built Artifacts
+  verify-release-artifacts:
+    name: Verify Release Artifacts
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [build]
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Install verification tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -69,11 +77,25 @@ jobs:
           name: dist-ubuntu-latest-py3.11
           path: artifacts
 
+      - name: Verify artifact presence
+        shell: bash
+        run: |
+          wheel_count="$(find artifacts -maxdepth 1 -type f -name '*.whl' | wc -l)"
+          sdist_count="$(find artifacts -maxdepth 1 -type f -name '*.tar.gz' | wc -l)"
+          if [ "$wheel_count" -eq 0 ] || [ "$sdist_count" -eq 0 ]; then
+            echo "Expected at least one wheel and one sdist before publish."
+            exit 1
+          fi
+          ls -l artifacts
+
+      - name: Validate distribution metadata
+        run: python -m twine check artifacts/*
+
       - name: Install wheel and run smoke test
         shell: bash
         run: |
-          python -m venv .venv
-          source .venv/bin/activate
+          python -m venv .wheel-venv
+          source .wheel-venv/bin/activate
           python -m pip install --upgrade pip
 
           wheel_path="$(find artifacts -type f -name '*.whl' | head -n 1)"
@@ -82,22 +104,28 @@ jobs:
             exit 1
           fi
           python -m pip install "$wheel_path"
+          python -c "import pyisolate; print(pyisolate.__version__)"
+
+      - name: Install sdist and run smoke test
+        shell: bash
+        run: |
+          python -m venv .sdist-venv
+          source .sdist-venv/bin/activate
+          python -m pip install --upgrade pip
 
           sdist_path="$(find artifacts -type f -name '*.tar.gz' | head -n 1)"
           if [ -z "$sdist_path" ]; then
             echo "No sdist artifact found."
             exit 1
           fi
-
-          temp_dir="$(mktemp -d)"
-          cd "$temp_dir"
+          python -m pip install "$sdist_path"
           python -c "import pyisolate; print(pyisolate.__version__)"
 
   publish:
     name: Publish To PyPI (Trusted Publishing)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, smoke-test]
+    needs: [build, verify-release-artifacts]
     if: >-
       github.repository == 'Comfy-Org/pyisolate' &&
       github.event_name == 'release' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,13 +119,22 @@ jobs:
         source .venv/bin/activate
         uv pip install -e ".[dev,test]"
 
-    - name: Run ruff
+    - name: Run ruff check
       run: |
         source .venv/bin/activate
         ruff check pyisolate tests
+
+    - name: Run ruff format check
+      run: |
+        source .venv/bin/activate
         ruff format --check pyisolate tests
 
     - name: Run mypy
       run: |
         source .venv/bin/activate
-        mypy pyisolate
+        mypy pyisolate tests
+
+    - name: Run pytest
+      run: |
+        source .venv/bin/activate
+        pytest -q

--- a/pyisolate/__init__.py
+++ b/pyisolate/__init__.py
@@ -44,7 +44,7 @@ from .sealed import SealedNodeExtension
 if TYPE_CHECKING:
     from .interfaces import IsolationAdapter
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 
 __all__ = [
     "ExtensionBase",

--- a/pyisolate/_internal/environment.py
+++ b/pyisolate/_internal/environment.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
+from packaging.utils import parse_wheel_filename
+
 from ..config import ExtensionConfig
 from ..path_helpers import serialize_host_snapshot
 from .cuda_wheels import (
@@ -90,12 +92,13 @@ def validate_backend_config(config: ExtensionConfig) -> None:
             "Specify at least one channel (e.g. ['conda-forge'])."
         )
 
-    # conda requires pixi on PATH
-    if not shutil.which("pixi"):
-        raise ValueError(
-            "pixi is required for conda backend but not found. "
-            "Install: curl -fsSL https://pixi.sh/install.sh | bash"
-        )
+    # conda requires pixi — auto-provision if not on PATH
+    from pyisolate._internal.pixi_provisioner import ensure_pixi
+
+    try:
+        ensure_pixi()
+    except Exception as e:
+        raise ValueError(f"pixi is required for conda backend but could not be provisioned: {e}") from e
 
 
 logger = logging.getLogger(__name__)
@@ -390,12 +393,12 @@ def install_dependencies(venv_path: Path, config: ExtensionConfig, name: str) ->
     if not safe_deps:
         return
 
+    from packaging.requirements import InvalidRequirement, Requirement
+    from packaging.utils import canonicalize_name
+
     cuda_wheels_config = config.get("cuda_wheels")
     cuda_wheel_runtime: dict[str, object] | None = None
     if cuda_wheels_config:
-        from packaging.requirements import InvalidRequirement, Requirement
-        from packaging.utils import canonicalize_name
-
         cuda_pkg_names = {canonicalize_name(p) for p in cuda_wheels_config.get("packages", [])}
         needs_cuda_probe = False
         for dep in safe_deps:
@@ -436,9 +439,13 @@ def install_dependencies(venv_path: Path, config: ExtensionConfig, name: str) ->
         torch_spec = f"torch=={torch_version}"
         safe_deps.insert(0, torch_spec)
 
+    for extra_url in config.get("extra_index_urls", []):
+        common_args += ["--extra-index-url", extra_url]
+
     descriptor = {
         "dependencies": safe_deps,
         "share_torch": config["share_torch"],
+        "share_torch_no_deps": config.get("share_torch_no_deps", []),
         "torch_spec": torch_spec,
         "cuda_wheels": cuda_wheels_config,
         "cuda_wheel_runtime": cuda_wheel_runtime,
@@ -497,42 +504,115 @@ def install_dependencies(venv_path: Path, config: ExtensionConfig, name: str) ->
             install_targets.append(dep)
         i += 1
 
+    def _run_uv_install(cmd: list[str], *, log_cuda_wheels: bool) -> None:
+        with subprocess.Popen(  # noqa: S603  # Trusted: validated pip/uv install cmd
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        ) as proc:
+            assert proc.stdout is not None
+            output_lines: list[str] = []
+            for line in proc.stdout:
+                clean = line.rstrip()
+                # Filter out pyisolate install messages to avoid polluting logs
+                # with internal dependency resolution noise that isn't actionable
+                # for users debugging their own extension dependencies.
+                if "pyisolate==" not in clean and "pyisolate @" not in clean:
+                    output_lines.append(clean)
+                    if log_cuda_wheels and clean:
+                        logger.info("][ CUDA_WHEEL_UV ext=%s %s", name, clean)
+            return_code = proc.wait()
+
+        if return_code != 0:
+            detail = "\n".join(output_lines) or "(no output)"
+            raise RuntimeError(f"Install failed for {name}: {detail}")
+
     if cuda_wheels_config:
-        redacted_targets = [
-            f"{urlparse(t).netloc}/{Path(urlparse(t).path).name}" if "://" in t else t
-            for t in install_targets
-        ]
-        logger.info(
-            "][ CUDA_WHEEL_INSTALL ext=%s targets=%s",
-            name,
-            redacted_targets,
-        )
+        cuda_package_dirs: set[str] = set()
+        package_map = cuda_wheels_config.get("package_map", {})
+        for package_name in cuda_wheels_config.get("packages", []):
+            for candidate in (
+                package_name,
+                package_name.replace("-", "_"),
+                package_name.replace("_", "-"),
+            ):
+                if candidate:
+                    cuda_package_dirs.add(candidate)
+            mapped_name = package_map.get(package_name)
+            if mapped_name:
+                for candidate in (
+                    mapped_name,
+                    mapped_name.replace("-", "_"),
+                    mapped_name.replace("_", "-"),
+                ):
+                    if candidate:
+                        cuda_package_dirs.add(candidate)
 
-    cmd = cmd_prefix + install_targets + common_args
+        regular_targets: list[str] = []
+        share_torch_no_deps_targets: list[str] = []
+        cuda_wheel_targets: list[str] = []
+        share_torch_no_deps = config.get("share_torch_no_deps", [])
+        if not isinstance(share_torch_no_deps, list):
+            share_torch_no_deps = []
+        share_torch_no_deps_names = {canonicalize_name(dep_name) for dep_name in share_torch_no_deps}
+        for target in install_targets:
+            if "://" not in target:
+                if config["share_torch"]:
+                    try:
+                        target_name: str = canonicalize_name(Requirement(target).name)
+                    except InvalidRequirement:
+                        target_name = ""
+                    if target_name and target_name in share_torch_no_deps_names:
+                        share_torch_no_deps_targets.append(target)
+                        continue
+                regular_targets.append(target)
+                continue
+            parsed = urlparse(target)
+            wheel_name = Path(parsed.path).name
+            distribution_name = ""
+            try:
+                distribution_name, _, _, _ = parse_wheel_filename(wheel_name)
+            except Exception:
+                distribution_name = ""
+            normalized_distribution = distribution_name.replace("-", "_")
+            if normalized_distribution in cuda_package_dirs:
+                cuda_wheel_targets.append(target)
+            else:
+                regular_targets.append(target)
 
-    with subprocess.Popen(  # noqa: S603  # Trusted: validated pip/uv install cmd
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
-    ) as proc:
-        assert proc.stdout is not None
-        output_lines: list[str] = []
-        for line in proc.stdout:
-            clean = line.rstrip()
-            # Filter out pyisolate install messages to avoid polluting logs
-            # with internal dependency resolution noise that isn't actionable
-            # for users debugging their own extension dependencies.
-            if "pyisolate==" not in clean and "pyisolate @" not in clean:
-                output_lines.append(clean)
-                if cuda_wheels_config and clean:
-                    logger.info("][ CUDA_WHEEL_UV ext=%s %s", name, clean)
-        return_code = proc.wait()
+        if cuda_wheel_targets:
+            redacted_targets = [
+                f"{urlparse(t).netloc}/{Path(urlparse(t).path).name}" for t in cuda_wheel_targets
+            ]
+            logger.info(
+                "][ CUDA_WHEEL_INSTALL ext=%s targets=%s",
+                name,
+                redacted_targets,
+            )
 
-    if return_code != 0:
-        detail = "\n".join(output_lines) or "(no output)"
-        raise RuntimeError(f"Install failed for {name}: {detail}")
+        if share_torch_no_deps_targets:
+            logger.info(
+                "][ TORCH_SHARE_NO_DEPS_INSTALL ext=%s targets=%s",
+                name,
+                share_torch_no_deps_targets,
+            )
+
+        if regular_targets:
+            _run_uv_install(cmd_prefix + regular_targets + common_args, log_cuda_wheels=False)
+        if share_torch_no_deps_targets:
+            _run_uv_install(
+                cmd_prefix + ["--no-deps"] + share_torch_no_deps_targets + common_args,
+                log_cuda_wheels=False,
+            )
+        if cuda_wheel_targets:
+            _run_uv_install(
+                cmd_prefix + ["--no-deps"] + cuda_wheel_targets + common_args,
+                log_cuda_wheels=True,
+            )
+    else:
+        _run_uv_install(cmd_prefix + install_targets + common_args, log_cuda_wheels=False)
 
     lock_path.write_text(
         json.dumps({"fingerprint": fingerprint, "descriptor": descriptor}, indent=2),

--- a/pyisolate/_internal/environment.py
+++ b/pyisolate/_internal/environment.py
@@ -529,8 +529,20 @@ def install_dependencies(venv_path: Path, config: ExtensionConfig, name: str) ->
             detail = "\n".join(output_lines) or "(no output)"
             raise RuntimeError(f"Install failed for {name}: {detail}")
 
+    share_torch_no_deps = config.get("share_torch_no_deps", [])
+    if not isinstance(share_torch_no_deps, list):
+        raise TypeError(
+            "share_torch_no_deps must be a list of dependency names, "
+            f"got {type(share_torch_no_deps).__name__}: {share_torch_no_deps!r}"
+        )
+
+    share_torch_no_deps_names = {canonicalize_name(dep_name) for dep_name in share_torch_no_deps}
+    regular_targets: list[str] = []
+    share_torch_no_deps_targets: list[str] = []
+    cuda_wheel_targets: list[str] = []
+    cuda_package_dirs: set[str] = set()
+
     if cuda_wheels_config:
-        cuda_package_dirs: set[str] = set()
         package_map = cuda_wheels_config.get("package_map", {})
         for package_name in cuda_wheels_config.get("packages", []):
             for candidate in (
@@ -550,38 +562,33 @@ def install_dependencies(venv_path: Path, config: ExtensionConfig, name: str) ->
                     if candidate:
                         cuda_package_dirs.add(candidate)
 
-        regular_targets: list[str] = []
-        share_torch_no_deps_targets: list[str] = []
-        cuda_wheel_targets: list[str] = []
-        share_torch_no_deps = config.get("share_torch_no_deps", [])
-        if not isinstance(share_torch_no_deps, list):
-            share_torch_no_deps = []
-        share_torch_no_deps_names = {canonicalize_name(dep_name) for dep_name in share_torch_no_deps}
-        for target in install_targets:
-            if "://" not in target:
-                if config["share_torch"]:
-                    try:
-                        target_name: str = canonicalize_name(Requirement(target).name)
-                    except InvalidRequirement:
-                        target_name = ""
-                    if target_name and target_name in share_torch_no_deps_names:
-                        share_torch_no_deps_targets.append(target)
-                        continue
-                regular_targets.append(target)
-                continue
-            parsed = urlparse(target)
-            wheel_name = Path(parsed.path).name
-            distribution_name = ""
-            try:
-                distribution_name, _, _, _ = parse_wheel_filename(wheel_name)
-            except Exception:
-                distribution_name = ""
-            normalized_distribution = distribution_name.replace("-", "_")
-            if normalized_distribution in cuda_package_dirs:
-                cuda_wheel_targets.append(target)
-            else:
-                regular_targets.append(target)
+    for target in install_targets:
+        if "://" not in target:
+            if config["share_torch"]:
+                try:
+                    target_name: str = canonicalize_name(Requirement(target).name)
+                except InvalidRequirement:
+                    target_name = ""
+                if target_name and target_name in share_torch_no_deps_names:
+                    share_torch_no_deps_targets.append(target)
+                    continue
+            regular_targets.append(target)
+            continue
 
+        parsed = urlparse(target)
+        wheel_name = Path(parsed.path).name
+        distribution_name = ""
+        try:
+            distribution_name, _, _, _ = parse_wheel_filename(wheel_name)
+        except Exception:
+            distribution_name = ""
+        normalized_distribution = distribution_name.replace("-", "_")
+        if cuda_wheels_config and normalized_distribution in cuda_package_dirs:
+            cuda_wheel_targets.append(target)
+        else:
+            regular_targets.append(target)
+
+    if cuda_wheels_config:
         if cuda_wheel_targets:
             redacted_targets = [
                 f"{urlparse(t).netloc}/{Path(urlparse(t).path).name}" for t in cuda_wheel_targets
@@ -612,7 +619,18 @@ def install_dependencies(venv_path: Path, config: ExtensionConfig, name: str) ->
                 log_cuda_wheels=True,
             )
     else:
-        _run_uv_install(cmd_prefix + install_targets + common_args, log_cuda_wheels=False)
+        if regular_targets:
+            _run_uv_install(cmd_prefix + regular_targets + common_args, log_cuda_wheels=False)
+        if share_torch_no_deps_targets:
+            logger.info(
+                "][ TORCH_SHARE_NO_DEPS_INSTALL ext=%s targets=%s",
+                name,
+                share_torch_no_deps_targets,
+            )
+            _run_uv_install(
+                cmd_prefix + ["--no-deps"] + share_torch_no_deps_targets + common_args,
+                log_cuda_wheels=False,
+            )
 
     lock_path.write_text(
         json.dumps({"fingerprint": fingerprint, "descriptor": descriptor}, indent=2),

--- a/pyisolate/_internal/environment_conda.py
+++ b/pyisolate/_internal/environment_conda.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.metadata
 import json
 import logging
 import os
@@ -154,7 +155,15 @@ def _generate_pixi_toml(config: ExtensionConfig) -> str:
             lines.append("")
 
         lines.append("[pypi-dependencies]")
-        lines.append(f'pyisolate = {{ path = "{_toml_path_string(_pyisolate_source_path())}" }}')
+        source_path = _pyisolate_source_path()
+        if (source_path / "pyproject.toml").exists():
+            lines.append(f'pyisolate = {{ path = "{_toml_path_string(source_path)}" }}')
+        else:
+            try:
+                version = importlib.metadata.version("pyisolate")
+            except importlib.metadata.PackageNotFoundError:
+                version = "0.0.0"
+            lines.append(f'pyisolate = "=={version}"')
         for dep in pip_deps:
             name_part, sep, version_part, extras, marker = _parse_dep(dep)
             if cuda_wheel_packages and canonicalize_name(name_part) in cuda_wheel_packages:
@@ -266,12 +275,9 @@ def create_conda_env(env_path: Path, config: ExtensionConfig, name: str) -> None
     """
     env_path.mkdir(parents=True, exist_ok=True)
 
-    pixi_path = shutil.which("pixi")
-    if not pixi_path:
-        raise RuntimeError(
-            "pixi is required for conda backend but not found on PATH. "
-            "Install: curl -fsSL https://pixi.sh/install.sh | bash"
-        )
+    from pyisolate._internal.pixi_provisioner import ensure_pixi
+
+    pixi_path = ensure_pixi()
 
     cuda_wheels_config = config.get("cuda_wheels")
 

--- a/pyisolate/_internal/pixi_provisioner.py
+++ b/pyisolate/_internal/pixi_provisioner.py
@@ -1,0 +1,177 @@
+"""Auto-provision the pixi binary for conda backend support.
+
+Downloads, caches, and integrity-verifies the pixi binary from prefix-dev
+GitHub releases. The binary is cached at ~/.cache/pyisolate/pixi/{version}/
+and reused across runs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import platform
+import shutil
+import stat
+import subprocess
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+PIXI_VERSION = "0.67.0"
+
+_PLATFORM_MAP = {
+    ("Linux", "x86_64"): "x86_64-unknown-linux-musl",
+    ("Linux", "aarch64"): "aarch64-unknown-linux-musl",
+    ("Darwin", "x86_64"): "x86_64-apple-darwin",
+    ("Darwin", "arm64"): "aarch64-apple-darwin",
+    ("Windows", "AMD64"): "x86_64-pc-windows-msvc",
+    ("Windows", "ARM64"): "aarch64-pc-windows-msvc",
+}
+
+
+def _binary_name() -> str:
+    return "pixi.exe" if platform.system() == "Windows" else "pixi"
+
+
+def _archive_extension() -> str:
+    return ".zip" if platform.system() == "Windows" else ".tar.gz"
+
+
+def _release_asset_name(target: str) -> str:
+    return f"pixi-{target}{_archive_extension()}"
+
+
+def _release_url(version: str, target: str) -> str:
+    asset = _release_asset_name(target)
+    return f"https://github.com/prefix-dev/pixi/releases/download/v{version}/{asset}"
+
+
+def _checksum_url(version: str, target: str) -> str:
+    asset = _release_asset_name(target)
+    return f"https://github.com/prefix-dev/pixi/releases/download/v{version}/{asset}.sha256"
+
+
+def _get_target() -> str:
+    system = platform.system()
+    machine = platform.machine()
+    key = (system, machine)
+    target = _PLATFORM_MAP.get(key)
+    if not target:
+        raise RuntimeError(
+            f"Unsupported platform for pixi auto-provisioning: {system}/{machine}. "
+            f"Supported: {', '.join(f'{s}/{m}' for s, m in _PLATFORM_MAP)}"
+        )
+    return target
+
+
+def _cache_dir(version: str) -> Path:
+    base = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return base / "pyisolate" / "pixi" / version
+
+
+def _fetch_url(url: str) -> bytes:
+    """Download a URL using urllib (stdlib, no extra deps)."""
+    import urllib.error
+    import urllib.request
+
+    if not url.startswith("https://"):
+        raise RuntimeError(f"Unsupported pixi download URL scheme: {url}")
+
+    req = urllib.request.Request(url, headers={"User-Agent": "pyisolate"})  # noqa: S310
+    with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310
+        data = resp.read()
+        if not isinstance(data, bytes):
+            raise RuntimeError(f"Unexpected pixi download payload type: {type(data).__name__}")
+        return data
+
+
+def _verify_checksum(data: bytes, expected_hex: str) -> None:
+    actual = hashlib.sha256(data).hexdigest()
+    if actual != expected_hex:
+        raise RuntimeError(f"pixi binary checksum mismatch: expected {expected_hex}, got {actual}")
+
+
+def ensure_pixi(version: str | None = None) -> str:
+    """Return path to pixi binary, downloading if necessary.
+
+    1. Check if pixi is already on PATH and matches the pinned version.
+    2. Check the cache directory for a previously downloaded binary.
+    3. Download from GitHub releases, verify checksum, cache, and return.
+    """
+    version = version or PIXI_VERSION
+
+    # Check PATH first
+    existing = shutil.which("pixi")
+    if existing:
+        try:
+            result = subprocess.run([existing, "--version"], capture_output=True, text=True, timeout=10)
+            if result.returncode == 0 and version in result.stdout:
+                return existing
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+
+    # Check cache
+    cache = _cache_dir(version)
+    cached_binary = cache / _binary_name()
+    if cached_binary.exists():
+        return str(cached_binary)
+
+    # Download
+    target = _get_target()
+    archive_url = _release_url(version, target)
+    checksum_url = _checksum_url(version, target)
+    archive_extension = _archive_extension()
+
+    logger.info("Downloading pixi %s for %s...", version, target)
+
+    checksum_data = _fetch_url(checksum_url)
+    expected_hash = checksum_data.decode().strip().split()[0]
+
+    archive_data = _fetch_url(archive_url)
+    _verify_checksum(archive_data, expected_hash)
+
+    # Extract
+    cache.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(suffix=archive_extension, delete=False) as tmp:
+        tmp.write(archive_data)
+        tmp_path = tmp.name
+
+    try:
+        binary_name = _binary_name()
+        if archive_extension == ".zip":
+            with zipfile.ZipFile(tmp_path) as zf:
+                members = zf.namelist()
+                member_name = binary_name
+                if member_name not in members:
+                    for member in members:
+                        if member.endswith(binary_name):
+                            member_name = member
+                            break
+                zf.extract(member_name, path=str(cache))
+                extracted = cache / member_name
+        else:
+            with tarfile.open(tmp_path, "r:gz") as tf:
+                members = tf.getnames()
+                member_name = binary_name
+                if member_name not in members:
+                    for member in members:
+                        if member.endswith(binary_name):
+                            member_name = member
+                            break
+                tf.extract(member_name, path=str(cache))
+                extracted = cache / member_name
+
+        if extracted != cached_binary:
+            extracted.rename(cached_binary)
+    finally:
+        os.unlink(tmp_path)
+
+    # Make executable
+    cached_binary.chmod(cached_binary.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    logger.info("pixi %s cached at %s", version, cached_binary)
+    return str(cached_binary)

--- a/pyisolate/_internal/pixi_provisioner.py
+++ b/pyisolate/_internal/pixi_provisioner.py
@@ -95,6 +95,29 @@ def _verify_checksum(data: bytes, expected_hex: str) -> None:
         raise RuntimeError(f"pixi binary checksum mismatch: expected {expected_hex}, got {actual}")
 
 
+def _safe_extract_member(
+    *,
+    cache: Path,
+    member_name: str,
+    binary_name: str,
+    data: bytes,
+    mode: int | None = None,
+) -> Path:
+    relative_member = Path(member_name)
+    target = (cache / relative_member.name).resolve()
+    cache_root = cache.resolve()
+    if target.parent != cache_root:
+        raise RuntimeError(f"Unsafe pixi archive path: {member_name}")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(data)
+    if mode is not None:
+        target.chmod(mode)
+    elif target.name == binary_name:
+        target.chmod(target.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return target
+
+
 def ensure_pixi(version: str | None = None) -> str:
     """Return path to pixi binary, downloading if necessary.
 
@@ -151,8 +174,13 @@ def ensure_pixi(version: str | None = None) -> str:
                         if member.endswith(binary_name):
                             member_name = member
                             break
-                zf.extract(member_name, path=str(cache))
-                extracted = cache / member_name
+                with zf.open(member_name) as member_fp:
+                    extracted = _safe_extract_member(
+                        cache=cache,
+                        member_name=member_name,
+                        binary_name=binary_name,
+                        data=member_fp.read(),
+                    )
         else:
             with tarfile.open(tmp_path, "r:gz") as tf:
                 members = tf.getnames()
@@ -162,8 +190,18 @@ def ensure_pixi(version: str | None = None) -> str:
                         if member.endswith(binary_name):
                             member_name = member
                             break
-                tf.extract(member_name, path=str(cache))
-                extracted = cache / member_name
+                tar_member = tf.getmember(member_name)
+                tar_member_fp = tf.extractfile(tar_member)
+                if tar_member_fp is None:
+                    raise RuntimeError(f"pixi archive member has no data: {member_name}")
+                with tar_member_fp:
+                    extracted = _safe_extract_member(
+                        cache=cache,
+                        member_name=member_name,
+                        binary_name=binary_name,
+                        data=tar_member_fp.read(),
+                        mode=tar_member.mode,
+                    )
 
         if extracted != cached_binary:
             extracted.rename(cached_binary)

--- a/pyisolate/_internal/rpc_protocol.py
+++ b/pyisolate/_internal/rpc_protocol.py
@@ -334,6 +334,20 @@ class AsyncRPC:
                 if t.is_alive() and t is not threading.current_thread():
                     t.join(timeout=2.0)
 
+    def _fail_pending_requests(self, error_msg: str) -> None:
+        with self.lock:
+            pending_items = list(self.pending.values())
+            self.pending.clear()
+
+        for pending_item in pending_items:
+            fut = pending_item["future"]
+            calling_loop = pending_item["calling_loop"]
+            self._schedule_future_resolution(
+                calling_loop,
+                fut,
+                exc=ConnectionError(error_msg),
+            )
+
     def run(self) -> None:
         self.blocking_future = self.default_loop.create_future()
         self._threads = [
@@ -482,18 +496,7 @@ class AsyncRPC:
                     # Fail all pending requests when connection dies
                     # preventing indefinite hangs in the host
                     error_msg = f"RPC connection lost: {exc}"
-                    with self.lock:
-                        pending_items = list(self.pending.values())
-                        self.pending.clear()
-
-                    for item in pending_items:
-                        fut = item["future"]
-                        calling_loop = item["calling_loop"]
-                        self._schedule_future_resolution(
-                            calling_loop,
-                            fut,
-                            exc=ConnectionError(error_msg),
-                        )
+                    self._fail_pending_requests(error_msg)
 
                     # Resolve blocking_future to unblock run_until_stopped
                     if self.blocking_future and not self.blocking_future.done():
@@ -505,6 +508,7 @@ class AsyncRPC:
                     break
 
                 if item is None:
+                    self._fail_pending_requests("RPC connection closed")
                     if self.blocking_future:
                         try:
                             loop = self._get_valid_loop(self.default_loop)

--- a/pyisolate/_internal/rpc_protocol.py
+++ b/pyisolate/_internal/rpc_protocol.py
@@ -152,6 +152,9 @@ class AsyncRPC:
         # Support both legacy queue interface and new transport interface
         if transport is not None:
             self._transport = transport
+            bind_rpc = getattr(self._transport, "bind_rpc", None)
+            if callable(bind_rpc):
+                bind_rpc(self)
         elif recv_queue is not None and send_queue is not None:
             self._transport = QueueTransport(send_queue, recv_queue)
         else:
@@ -166,6 +169,32 @@ class AsyncRPC:
         self.blocking_future: asyncio.Future[Any] | None = None
         self.outbox: queue.Queue[RPCPendingRequest | None] = queue.Queue()
         self._stopping: bool = False
+
+    @staticmethod
+    def _resolve_future_safely(
+        future: asyncio.Future[Any],
+        result: Any | None = None,
+        exc: BaseException | None = None,
+    ) -> None:
+        if future.done():
+            return
+        if exc is not None:
+            future.set_exception(exc)
+        else:
+            future.set_result(result)
+
+    def _schedule_future_resolution(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        future: asyncio.Future[Any],
+        *,
+        result: Any | None = None,
+        exc: BaseException | None = None,
+    ) -> None:
+        if loop.is_closed():
+            return
+        with contextlib.suppress(RuntimeError):
+            loop.call_soon_threadsafe(self._resolve_future_safely, future, result, exc)
 
     def update_event_loop(self, loop: asyncio.AbstractEventLoop | None = None) -> None:
         """
@@ -281,6 +310,11 @@ class AsyncRPC:
         # Unblock the _send_thread
         self.outbox.put(None)
 
+        # Ask the peer to exit recv() cleanly before closing the socket locally.
+        if hasattr(self, "_transport"):
+            with contextlib.suppress(Exception):
+                self._transport.send(None)
+
         # Unblock the _recv_thread by closing the transport
         if hasattr(self, "_transport"):
             with contextlib.suppress(Exception):
@@ -290,7 +324,7 @@ class AsyncRPC:
         if self.blocking_future and not self.blocking_future.done():
             try:
                 loop = self._get_valid_loop(self.default_loop)
-                loop.call_soon_threadsafe(self.blocking_future.set_result, None)
+                self._schedule_future_resolution(loop, self.blocking_future, result=None)
             except (RuntimeError, Exception):
                 pass
 
@@ -455,17 +489,17 @@ class AsyncRPC:
                     for item in pending_items:
                         fut = item["future"]
                         calling_loop = item["calling_loop"]
-                        if not calling_loop.is_closed():
-                            with contextlib.suppress(RuntimeError):
-                                calling_loop.call_soon_threadsafe(
-                                    fut.set_exception, ConnectionError(error_msg)
-                                )
+                        self._schedule_future_resolution(
+                            calling_loop,
+                            fut,
+                            exc=ConnectionError(error_msg),
+                        )
 
                     # Resolve blocking_future to unblock run_until_stopped
                     if self.blocking_future and not self.blocking_future.done():
                         try:
                             loop = self._get_valid_loop(self.default_loop)
-                            loop.call_soon_threadsafe(self.blocking_future.set_result, None)
+                            self._schedule_future_resolution(loop, self.blocking_future, result=None)
                         except RuntimeError:
                             pass
                     break
@@ -474,7 +508,7 @@ class AsyncRPC:
                     if self.blocking_future:
                         try:
                             loop = self._get_valid_loop(self.default_loop)
-                            loop.call_soon_threadsafe(self.blocking_future.set_result, None)
+                            self._schedule_future_resolution(loop, self.blocking_future, result=None)
                         except RuntimeError:
                             pass  # Loop closed, blocking_future won't be awaited anyway
                     break
@@ -498,12 +532,16 @@ class AsyncRPC:
 
                         try:
                             if item.get("error"):
-                                calling_loop.call_soon_threadsafe(
-                                    pending_request["future"].set_exception, Exception(item["error"])
+                                self._schedule_future_resolution(
+                                    calling_loop,
+                                    pending_request["future"],
+                                    exc=Exception(item["error"]),
                                 )
                             else:
-                                calling_loop.call_soon_threadsafe(
-                                    pending_request["future"].set_result, item["result"]
+                                self._schedule_future_resolution(
+                                    calling_loop,
+                                    pending_request["future"],
+                                    result=item["result"],
                                 )
 
                         except RuntimeError as e:
@@ -603,11 +641,11 @@ class AsyncRPC:
                             pending = self.pending.pop(call_id, None)
                         if pending:
                             calling_loop = pending["calling_loop"]
-                            if not calling_loop.is_closed():
-                                with contextlib.suppress(RuntimeError):
-                                    calling_loop.call_soon_threadsafe(
-                                        pending["future"].set_exception, RuntimeError(str(exc))
-                                    )
+                            self._schedule_future_resolution(
+                                calling_loop,
+                                pending["future"],
+                                exc=RuntimeError(str(exc)),
+                            )
                         # Don't raise, just log, so thread stays alive
                         logger.error(f"RPC Send Failed: {exc}")
 
@@ -636,11 +674,11 @@ class AsyncRPC:
                             pending = self.pending.pop(call_id, None)
                         if pending:
                             calling_loop = pending["calling_loop"]
-                            if not calling_loop.is_closed():
-                                with contextlib.suppress(RuntimeError):
-                                    calling_loop.call_soon_threadsafe(
-                                        pending["future"].set_exception, RuntimeError(str(exc))
-                                    )
+                            self._schedule_future_resolution(
+                                calling_loop,
+                                pending["future"],
+                                exc=RuntimeError(str(exc)),
+                            )
                         logger.error(f"RPC Callback Send Failed: {exc}")
 
                 elif typed_item["kind"] == "response":

--- a/pyisolate/_internal/rpc_serialization.py
+++ b/pyisolate/_internal/rpc_serialization.py
@@ -40,10 +40,12 @@ class CallableProxy:
     This allows inspect.signature() to work on the proxy
     """
 
-    def __init__(self, metadata: dict[str, Any]):
+    def __init__(self, metadata: dict[str, Any], rpc: Any | None = None):
         self._metadata = metadata
         self._name = metadata.get("name", "<remote_callable>")
         self._type_name = metadata.get("type", "Callable")
+        self._callback_id = metadata.get("callback_id")
+        self._rpc = rpc
 
         # Reconstruct signature if available
         sig_data = metadata.get("signature")
@@ -79,15 +81,13 @@ class CallableProxy:
 
             self.__signature__ = inspect.Signature(parameters=parameters)
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        # TODO: Implement full RPC callback support
-        # For now, we primarily need introspection to pass checks.
-        # Execution requires registering the callback ID on the sender side
-        # and handling the reverse RPC call here.
-        raise NotImplementedError(
-            f"Remote execution of {self._name} is not yet fully implemented. "
-            "Verification checks (inspect.signature) should pass."
-        )
+    async def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        if self._rpc is None or not self._callback_id:
+            raise NotImplementedError(
+                f"Remote execution of {self._name} is not available: "
+                "callable proxy is missing RPC callback binding."
+            )
+        return await self._rpc.call_callback(self._callback_id, *args, **kwargs)
 
     def __repr__(self) -> str:
         return f"<CallableProxy for {self._name}>"
@@ -347,23 +347,7 @@ def _tensor_to_cuda(obj: Any, device: Any | None = None) -> Any:
             if has:
                 deserializer = registry.get_deserializer(ref_type)
                 if deserializer:
-                    result = deserializer(obj)
-                    logger.warning(
-                        "][ DIAG: __type__=%s -> %s",
-                        ref_type,
-                        type(result).__name__,
-                    )
-                    return result
-                else:
-                    logger.warning(
-                        "][ DIAG: __type__=%s no deserializer",
-                        ref_type,
-                    )
-            else:
-                logger.warning(
-                    "][ DIAG: __type__=%s no handler",
-                    ref_type,
-                )
+                    return deserializer(obj)
 
         # Handle pyisolate internal container types
         if obj.get("__pyisolate_attribute_container__") and "data" in obj:

--- a/pyisolate/_internal/rpc_transports.py
+++ b/pyisolate/_internal/rpc_transports.py
@@ -112,6 +112,10 @@ class JSONSocketTransport:
         self._lock = threading.Lock()
         self._recv_lock = threading.Lock()
         self._tensor_transport = tensor_transport
+        self._rpc = None
+
+    def bind_rpc(self, rpc: Any) -> None:
+        self._rpc = rpc
 
     def set_tensor_transport_mode(self, tensor_transport: str) -> None:
         self._tensor_transport = tensor_transport
@@ -204,11 +208,16 @@ class JSONSocketTransport:
                 # Some callables (e.g. builtins) might not have signature
                 pass
 
+            callback_id = None
+            if self._rpc is not None:
+                callback_id = self._rpc.register_callback(obj)
+
             return {
                 "__pyisolate_callable__": True,
                 "type": type(obj).__name__,
                 "name": getattr(obj, "__name__", str(obj)),
                 "signature": sig_metadata,
+                "callback_id": callback_id,
             }
 
         # Handle exceptions explicitly
@@ -486,6 +495,6 @@ class JSONSocketTransport:
         if dct.get("__pyisolate_callable__"):
             from .rpc_serialization import CallableProxy
 
-            return CallableProxy(dct)
+            return CallableProxy(dct, rpc=self._rpc)
 
         return dct

--- a/pyisolate/_internal/tensor_serializer.py
+++ b/pyisolate/_internal/tensor_serializer.py
@@ -441,21 +441,41 @@ def deserialize_tensor(data: dict[str, Any], mode: str = "shared_memory") -> Any
 def _deserialize_json_tensor(data: dict[str, Any]) -> Any:
     """Deserialize a JSON tensor payload.
 
-    If torch is unavailable in the receiving process, leave the JSON payload intact
-    so sealed workers can still inspect or echo it without importing torch.
+    If torch is unavailable (sealed workers), deserialize to numpy array instead.
     """
     try:
         torch, _ = require_torch("JSON tensor deserialization")
     except Exception:
-        return data
+        torch = None
 
+    if torch is not None:
+        dtype_str = data["dtype"]
+        dtype = getattr(torch, dtype_str.split(".")[-1])
+        tensor = torch.tensor(data["data"], dtype=dtype)
+        tensor = tensor.reshape(tuple(data["tensor_size"]))
+        if data.get("requires_grad"):
+            tensor.requires_grad_(True)
+        return tensor
+
+    # Torch unavailable — deserialize to numpy for sealed workers
+    import numpy as np
+
+    torch_to_numpy_dtype = {
+        "torch.float16": np.float16,
+        "torch.float32": np.float32,
+        "torch.float64": np.float64,
+        "torch.bfloat16": np.float32,  # numpy has no bfloat16; upcast
+        "torch.int8": np.int8,
+        "torch.int16": np.int16,
+        "torch.int32": np.int32,
+        "torch.int64": np.int64,
+        "torch.uint8": np.uint8,
+        "torch.bool": np.bool_,
+    }
     dtype_str = data["dtype"]
-    dtype = getattr(torch, dtype_str.split(".")[-1])
-    tensor = torch.tensor(data["data"], dtype=dtype)
-    tensor = tensor.reshape(tuple(data["tensor_size"]))
-    if data.get("requires_grad"):
-        tensor.requires_grad_(True)
-    return tensor
+    np_dtype = torch_to_numpy_dtype.get(dtype_str, np.float32)
+    arr = np.array(data["data"], dtype=np_dtype).reshape(tuple(data["tensor_size"]))
+    return arr
 
 
 def _convert_lists_to_tuples(obj: Any) -> Any:
@@ -594,3 +614,19 @@ def register_tensor_serializer(registry: Any, mode: str = "shared_memory") -> No
     registry.register("dtype", serialize_dtype, deserialize_dtype)
     registry.register("device", serialize_device, deserialize_device)
     registry.register("Size", serialize_size, deserialize_size)
+
+
+def register_sealed_tensor_deserializer(registry: Any) -> None:
+    """Register TensorValue deserializer for sealed workers (no torch required).
+
+    Sealed workers receive tensors as JSON TensorValue dicts. This registers
+    a numpy-only deserializer so the data arrives as numpy arrays, not raw dicts.
+    """
+
+    def deserializer(data: dict[str, Any]) -> Any:
+        return _deserialize_json_tensor(data)
+
+    if not registry.has_handler("TensorValue"):
+        registry.register("TensorValue", None, deserializer)
+    if not registry.has_handler("TensorRef"):
+        registry.register("TensorRef", None, deserializer)

--- a/pyisolate/_internal/tensor_serializer.py
+++ b/pyisolate/_internal/tensor_serializer.py
@@ -473,7 +473,10 @@ def _deserialize_json_tensor(data: dict[str, Any]) -> Any:
         "torch.bool": np.bool_,
     }
     dtype_str = data["dtype"]
-    np_dtype = torch_to_numpy_dtype.get(dtype_str, np.float32)
+    if dtype_str not in torch_to_numpy_dtype:
+        supported = ", ".join(sorted(torch_to_numpy_dtype))
+        raise ValueError(f"Unsupported TensorValue dtype {dtype_str!r}. Supported dtypes: {supported}")
+    np_dtype = torch_to_numpy_dtype[dtype_str]
     arr = np.array(data["data"], dtype=np_dtype).reshape(tuple(data["tensor_size"]))
     return arr
 

--- a/pyisolate/_internal/uds_client.py
+++ b/pyisolate/_internal/uds_client.py
@@ -186,6 +186,12 @@ async def _async_uds_entrypoint(
         raise RuntimeError(
             "share_torch=True requires PyTorch. Install 'torch' to use tensor-sharing features."
         )
+    else:
+        # Sealed worker without torch — register numpy-only TensorValue deserializer
+        from .serialization_registry import SerializerRegistry
+        from .tensor_serializer import register_sealed_tensor_deserializer
+
+        register_sealed_tensor_deserializer(SerializerRegistry.get_instance())
 
     # Instantiate extension
     extension = extension_type()

--- a/pyisolate/config.py
+++ b/pyisolate/config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from enum import Enum
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 if sys.version_info >= (3, 11):
     from typing import NotRequired
@@ -86,7 +86,7 @@ class ExtensionConfig(TypedDict):
     share_cuda_ipc: bool
     """If True, attempt CUDA IPC-based tensor transport (Linux only, requires ``share_torch``)."""
 
-    sandbox: NotRequired[dict[str, Any]]
+    sandbox: NotRequired[SandboxConfig]
     """Configuration for the sandbox (e.g. writable_paths, network access)."""
 
     sandbox_mode: NotRequired[SandboxMode]

--- a/pyisolate/config.py
+++ b/pyisolate/config.py
@@ -65,8 +65,11 @@ class ExtensionConfig(TypedDict):
     name: str
     """Unique name for the extension (used for venv directory naming)."""
 
-    module_path: str
+    module_path: NotRequired[str]
     """Filesystem path to the extension package containing ``__init__.py``."""
+
+    module: NotRequired[str]
+    """Legacy module identifier used by some sealed/conda manifests and tests."""
 
     isolated: bool
     """Whether to run the extension in an isolated venv versus the host process."""
@@ -83,14 +86,14 @@ class ExtensionConfig(TypedDict):
     share_cuda_ipc: bool
     """If True, attempt CUDA IPC-based tensor transport (Linux only, requires ``share_torch``)."""
 
-    sandbox: dict[str, Any]
+    sandbox: NotRequired[dict[str, Any]]
     """Configuration for the sandbox (e.g. writable_paths, network access)."""
 
-    sandbox_mode: SandboxMode
+    sandbox_mode: NotRequired[SandboxMode]
     """Sandbox enforcement mode. Default is REQUIRED (fail if bwrap unavailable).
     Set to DISABLED only if you fully trust all code and accept the security risk."""
 
-    env: dict[str, str]
+    env: NotRequired[dict[str, str]]
     """Environment variable overrides for the child process."""
 
     package_manager: NotRequired[str]
@@ -113,3 +116,6 @@ class ExtensionConfig(TypedDict):
 
     cuda_wheels: NotRequired[CUDAWheelConfig]
     """Optional custom CUDA wheel resolution configuration for selected dependencies."""
+
+    extra_index_urls: NotRequired[list[str]]
+    """Extra PyPI index URLs passed as ``--extra-index-url`` to ``uv pip install``."""

--- a/pyisolate/sealed.py
+++ b/pyisolate/sealed.py
@@ -77,9 +77,10 @@ class SealedNodeExtension(ExtensionBase):
 
         def serialize_ndarray_as_tensor_value(obj: Any) -> dict[str, Any]:
             arr = np.asarray(obj)
-            dtype_str = numpy_to_torch_dtype.get(arr.dtype.type, "torch.float32")
             if arr.dtype.type not in numpy_to_torch_dtype:
-                arr = arr.astype(np.float32)
+                supported = ", ".join(sorted(dtype.__name__ for dtype in numpy_to_torch_dtype))
+                raise TypeError(f"Unsupported ndarray dtype {arr.dtype}. Supported dtypes: {supported}")
+            dtype_str = numpy_to_torch_dtype[arr.dtype.type]
             return {
                 "__type__": "TensorValue",
                 "dtype": dtype_str,

--- a/pyisolate/sealed.py
+++ b/pyisolate/sealed.py
@@ -47,6 +47,48 @@ class SealedNodeExtension(ExtensionBase):
         self.node_instances: dict[str, Any] = {}
         self.remote_objects: dict[str, Any] = {}
         self._module: ModuleType | None = None
+        self._register_ndarray_serializer()
+
+    @staticmethod
+    def _register_ndarray_serializer() -> None:
+        """Register ndarray→TensorValue serializer so _wrap_for_transport passes arrays inline."""
+        try:
+            import numpy as np
+        except ImportError:
+            return
+
+        from ._internal.serialization_registry import SerializerRegistry
+
+        registry = SerializerRegistry.get_instance()
+        if registry.has_handler("ndarray"):
+            return
+
+        numpy_to_torch_dtype = {
+            np.float32: "torch.float32",
+            np.float64: "torch.float64",
+            np.float16: "torch.float16",
+            np.int32: "torch.int32",
+            np.int64: "torch.int64",
+            np.int16: "torch.int16",
+            np.int8: "torch.int8",
+            np.uint8: "torch.uint8",
+            np.bool_: "torch.bool",
+        }
+
+        def serialize_ndarray_as_tensor_value(obj: Any) -> dict[str, Any]:
+            arr = np.asarray(obj)
+            dtype_str = numpy_to_torch_dtype.get(arr.dtype.type, "torch.float32")
+            if arr.dtype.type not in numpy_to_torch_dtype:
+                arr = arr.astype(np.float32)
+            return {
+                "__type__": "TensorValue",
+                "dtype": dtype_str,
+                "tensor_size": list(arr.shape),
+                "requires_grad": False,
+                "data": arr.tolist(),
+            }
+
+        registry.register("ndarray", serialize_ndarray_as_tensor_value, None, data_type=True)
 
     async def on_module_loaded(self, module: ModuleType) -> None:
         self._module = module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyisolate"
-version = "0.10.1"
+version = "0.10.2"
 description = "A Python library for dividing execution across multiple virtual environments"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,9 @@ Add any shared fixtures or pytest configuration here.
 
 import logging
 import sys
+from collections.abc import Generator
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -14,7 +16,7 @@ from pyisolate._internal.singleton_context import singleton_scope
 
 
 @pytest.fixture(autouse=True)
-def clean_singletons():
+def clean_singletons() -> Generator[None, None, None]:
     """Auto-cleanup fixture for singleton isolation between tests.
 
     This fixture runs automatically for all tests and ensures that:
@@ -30,7 +32,7 @@ def clean_singletons():
 
 
 @pytest.fixture
-def patch_extension_launch(monkeypatch):
+def patch_extension_launch(monkeypatch: Any) -> Any:
     """Prevent real subprocess launches during unit tests.
 
     NOTE: This fixture is NOT autouse - integration tests should NOT use it.
@@ -38,10 +40,10 @@ def patch_extension_launch(monkeypatch):
     """
     from pyisolate._internal import host as host_internal
 
-    original_launch = host_internal.Extension._Extension__launch
+    original_launch = host_internal.Extension._Extension__launch  # type: ignore[attr-defined]
     host_internal.Extension._orig_launch = original_launch  # type: ignore[attr-defined]
 
-    def dummy_launch(self):
+    def dummy_launch(self: Any) -> Any:
         return SimpleNamespace(
             is_alive=lambda: False,
             terminate=lambda: None,
@@ -54,7 +56,7 @@ def patch_extension_launch(monkeypatch):
     monkeypatch.setattr(host_internal.Extension, "_Extension__launch", original_launch)
 
 
-def pytest_configure(config):
+def pytest_configure(config: Any) -> None:
     """Configure pytest with custom settings."""
     # Register custom markers
     config.addinivalue_line("markers", "slow: marks tests as slow (>5s, deselect with -m 'not slow')")
@@ -87,7 +89,7 @@ def pytest_configure(config):
         logging.getLogger().addHandler(file_handler)
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Any) -> None:
     """Add custom command line options."""
     parser.addoption(
         "--debug-pyisolate",

--- a/tests/fixtures/conda_sealed_node/__init__.py
+++ b/tests/fixtures/conda_sealed_node/__init__.py
@@ -54,7 +54,7 @@ class OpenWeatherDatasetNode:
         return {"required": {}}
 
     def open_dataset(self) -> tuple[float, str]:
-        from boltons import strutils
+        from boltons import strutils  # type: ignore[import-untyped]
         from packaging.version import Version
 
         artifact_dir = Path(os.environ["PYISOLATE_ARTIFACT_DIR"])

--- a/tests/fixtures/test_adapter.py
+++ b/tests/fixtures/test_adapter.py
@@ -52,13 +52,13 @@ class MockTestData:
         value: The wrapped value to serialize.
     """
 
-    def __init__(self, value: Any):
+    def __init__(self, value: Any) -> None:
         self.value = value
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, MockTestData):
             return False
-        return self.value == other.value
+        return bool(self.value == other.value)
 
     def __repr__(self) -> str:
         return f"MockTestData({self.value!r})"
@@ -83,7 +83,7 @@ class MockRegistry(ProxiedSingleton):
         obj = registry.get(obj_id)  # Returns {"key": "value"}
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self._store: dict[str, Any] = {}
         self._counter = 0
@@ -142,7 +142,7 @@ class MockHostAdapter(IsolationAdapter):
         assert config["preferred_root"] == "/tmp/myhost"
     """
 
-    def __init__(self, root_path: str = "/tmp/testhost"):
+    def __init__(self, root_path: str = "/tmp/testhost") -> None:
         self._root = root_path
         self._extensions_dir = f"{root_path}/extensions"
 
@@ -161,7 +161,7 @@ class MockHostAdapter(IsolationAdapter):
         """
         return "testhost"
 
-    def get_path_config(self, module_path: str) -> dict[str, Any] | None:
+    def get_path_config(self, module_path: str) -> dict[str, Any]:
         """Compute path configuration for an extension.
 
         This method tells pyisolate how to configure sys.path for
@@ -299,3 +299,16 @@ class MockHostAdapter(IsolationAdapter):
         Note:
             This is optional. Many adapters leave this empty.
         """
+        return None
+
+    def setup_web_directory(self, module: Any) -> None:
+        return None
+
+    def setup_child_event_hooks(self, rpc: AsyncRPC) -> None:
+        return None
+
+    def get_sandbox_system_paths(self) -> list[str]:
+        return []
+
+    def get_sandbox_gpu_patterns(self) -> list[str]:
+        return []

--- a/tests/fixtures/uv_sealed_worker/__init__.py
+++ b/tests/fixtures/uv_sealed_worker/__init__.py
@@ -31,7 +31,7 @@ class UVSealedRuntimeProbeNode:
         return {"required": {}}
 
     def probe(self) -> tuple[str, str, str, bool]:
-        from boltons import strutils
+        from boltons import strutils  # type: ignore[import-untyped]
 
         artifact_dir = _artifact_dir()
         path_dump = "\n".join(sys.path)
@@ -60,7 +60,7 @@ class UVSealedBoltonsSlugifyNode:
         return {"required": {"text": ("STRING",)}}
 
     def slug(self, text: str) -> tuple[str, str]:
-        from boltons import strutils
+        from boltons import strutils  # type: ignore[import-untyped]
 
         return (strutils.slugify(text, delim="_"), strutils.__file__)
 

--- a/tests/harness/host.py
+++ b/tests/harness/host.py
@@ -3,8 +3,9 @@ import logging
 import os
 import sys
 import tempfile
+from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, cast
 
 import pytest
 
@@ -19,16 +20,6 @@ from pyisolate.interfaces import SerializerRegistryProtocol
 from tests.harness.test_package import ReferenceTestExtension
 
 logger = logging.getLogger(__name__)
-
-
-class TestExtensionProtocol(Protocol):
-    async def ping(self) -> str: ...
-    async def echo_tensor(self, tensor: Any) -> Any: ...
-    async def allocate_cuda(self, size_mb: int) -> dict[str, Any]: ...
-    async def write_file(self, path: str, content: str) -> str: ...
-    async def read_file(self, path: str) -> str: ...
-    async def crash_me(self) -> None: ...
-    async def get_env_var(self, key: str) -> str | None: ...
 
 
 class ReferenceAdapter:
@@ -70,7 +61,7 @@ class ReferenceHost:
     A verbose host harness for running integration tests.
     """
 
-    def __init__(self, use_temp_dir: bool = True):
+    def __init__(self, use_temp_dir: bool = True) -> None:
         self.temp_dir: tempfile.TemporaryDirectory | None = None
         self.root_dir: Path = Path(os.getcwd())
         self._had_previous_tmpdir = "TMPDIR" in os.environ
@@ -95,13 +86,13 @@ class ReferenceHost:
         os.environ.setdefault("PYISOLATE_UV_CACHE_DIR", str(shared_uv_cache))
         os.environ.setdefault("UV_HTTP_TIMEOUT", "180")
 
-        self.extensions: list[Extension[TestExtensionProtocol]] = []
+        self.extensions: list[Extension[ReferenceTestExtension]] = []
         self._adapter_registered = False
         self.sandbox_available = True
         if sys.platform == "linux":
             self.sandbox_available = detect_sandbox_capability().available
 
-    def setup(self):
+    def setup(self) -> None:
         """Initialize the host environment."""
         # Ensure uv is in PATH
         # Since we run tests with the venv python, uv should be in the same bin dir
@@ -115,7 +106,7 @@ class ReferenceHost:
 
         # Register our reference adapter
         self.adapter = ReferenceAdapter()
-        AdapterRegistry.register(self.adapter)
+        AdapterRegistry.register(cast(Any, self.adapter))
         self._adapter_registered = True
 
         # Ensure proper torch multiprocessing setup
@@ -136,7 +127,7 @@ class ReferenceHost:
         share_torch: bool = True,
         share_cuda: bool = False,
         extra_deps: list[str] | None = None,
-    ) -> Extension[TestExtensionProtocol]:
+    ) -> Extension[ReferenceTestExtension]:
         """
         Loads the static reference extension.
         """
@@ -183,7 +174,7 @@ class ReferenceHost:
         self.extensions.append(ext)
         return ext
 
-    async def cleanup(self):
+    async def cleanup(self) -> None:
         """Stop all extensions and cleanup resources."""
         cleanup_errors = []
 
@@ -219,7 +210,7 @@ class ReferenceHost:
 
 
 @pytest.fixture
-async def reference_host():
+async def reference_host() -> AsyncGenerator[ReferenceHost, None]:
     host = ReferenceHost()
     host.setup()
     yield host

--- a/tests/harness/host.py
+++ b/tests/harness/host.py
@@ -14,7 +14,7 @@ import tests.harness.test_package as test_package_module
 from pyisolate._internal.adapter_registry import AdapterRegistry
 from pyisolate._internal.rpc_protocol import AsyncRPC, ProxiedSingleton
 from pyisolate._internal.sandbox_detect import detect_sandbox_capability
-from pyisolate.config import ExtensionConfig, SandboxMode
+from pyisolate.config import ExtensionConfig, SandboxConfig, SandboxMode
 from pyisolate.host import Extension
 from pyisolate.interfaces import SerializerRegistryProtocol
 from tests.harness.test_package import ReferenceTestExtension
@@ -145,9 +145,8 @@ class ReferenceHost:
             pass  # We rely on site-packages inheritance for torch usually
 
         # Sandbox Config for IPC
-        sandbox_cfg = {
+        sandbox_cfg: SandboxConfig = {
             "writable_paths": [str(self.shared_tmp)],
-            "doc": "Required for Torch/PyTorch file_system IPC strategy",
         }
 
         ext_config = ExtensionConfig(
@@ -206,12 +205,14 @@ class ReferenceHost:
             os.environ.pop("TMPDIR", None)
 
         if cleanup_errors:
-            pass
+            raise RuntimeError("ReferenceHost cleanup failed: " + "; ".join(cleanup_errors))
 
 
 @pytest.fixture
 async def reference_host() -> AsyncGenerator[ReferenceHost, None]:
     host = ReferenceHost()
-    host.setup()
-    yield host
-    await host.cleanup()
+    try:
+        host.setup()
+        yield host
+    finally:
+        await host.cleanup()

--- a/tests/integration_v2/conftest.py
+++ b/tests/integration_v2/conftest.py
@@ -9,8 +9,8 @@ from tests.harness.host import ReferenceHost
 async def reference_host() -> AsyncGenerator[ReferenceHost, None]:
     """Provides a ReferenceHost instance."""
     host = ReferenceHost()
-    host.setup()
     try:
+        host.setup()
         yield host
     finally:
         await host.cleanup()

--- a/tests/integration_v2/conftest.py
+++ b/tests/integration_v2/conftest.py
@@ -1,10 +1,12 @@
+from collections.abc import AsyncGenerator
+
 import pytest
 
 from tests.harness.host import ReferenceHost
 
 
 @pytest.fixture
-async def reference_host():
+async def reference_host() -> AsyncGenerator[ReferenceHost, None]:
     """Provides a ReferenceHost instance."""
     host = ReferenceHost()
     host.setup()

--- a/tests/integration_v2/debug_rpc.py
+++ b/tests/integration_v2/debug_rpc.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from typing import Any
 
 import pytest
 
@@ -9,7 +10,7 @@ logging.getLogger("pyisolate").setLevel(logging.DEBUG)
 
 
 @pytest.mark.asyncio
-async def test_debug_ping(reference_host):
+async def test_debug_ping(reference_host: Any) -> None:
     print("\n--- Starting Debug Ping ---")
     ext = reference_host.load_test_extension("debug_ping", isolated=True)
 

--- a/tests/integration_v2/test_isolation.py
+++ b/tests/integration_v2/test_isolation.py
@@ -2,6 +2,7 @@ import os
 import sys
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -18,7 +19,7 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.mark.asyncio
-async def test_filesystem_barrier(reference_host):
+async def test_filesystem_barrier(reference_host: Any) -> None:
     """
     Verify that the child process cannot write to restricted paths on the host.
     """
@@ -69,7 +70,7 @@ async def test_filesystem_barrier(reference_host):
 
 
 @pytest.mark.asyncio
-async def test_module_path_ro(reference_host):
+async def test_module_path_ro(reference_host: Any) -> None:
     """Verify module path is read-only in child."""
     ext = reference_host.load_test_extension("ro_test", isolated=True)
     proxy = ext.get_proxy()
@@ -86,7 +87,7 @@ async def test_module_path_ro(reference_host):
 
 
 @pytest.mark.asyncio
-async def test_host_tmp_marker_hidden_from_child(reference_host):
+async def test_host_tmp_marker_hidden_from_child(reference_host: Any) -> None:
     """Verify host /tmp is hidden while child /tmp remains writable."""
     host_marker = Path(tempfile.mkstemp(prefix="pyisolate_host_tmp_", dir="/tmp")[1])
     child_scratch = "/tmp/child_scratch.txt"

--- a/tests/integration_v2/test_isolation.py
+++ b/tests/integration_v2/test_isolation.py
@@ -12,10 +12,13 @@ _SANDBOX_AVAILABLE = False
 if sys.platform == "linux":
     _SANDBOX_AVAILABLE = detect_sandbox_capability().available
 
-pytestmark = pytest.mark.skipif(
-    not _SANDBOX_AVAILABLE,
-    reason="filesystem barrier checks require a working Linux bubblewrap sandbox",
-)
+pytestmark = [
+    pytest.mark.network,
+    pytest.mark.skipif(
+        not _SANDBOX_AVAILABLE,
+        reason="filesystem barrier checks require a working Linux bubblewrap sandbox",
+    ),
+]
 
 
 @pytest.mark.asyncio

--- a/tests/integration_v2/test_lifecycle.py
+++ b/tests/integration_v2/test_lifecycle.py
@@ -1,8 +1,10 @@
+from typing import Any
+
 import pytest
 
 
 @pytest.mark.asyncio
-async def test_extension_lifecycle(reference_host):
+async def test_extension_lifecycle(reference_host: Any) -> None:
     """
     Verifies:
     1. Extension can actally accept a connection.
@@ -23,7 +25,7 @@ async def test_extension_lifecycle(reference_host):
 
 
 @pytest.mark.asyncio
-async def test_non_isolated_lifecycle(reference_host):
+async def test_non_isolated_lifecycle(reference_host: Any) -> None:
     """
     Verifies standard mode (host-loaded) works with same API.
     """

--- a/tests/integration_v2/test_rpc_coverage.py
+++ b/tests/integration_v2/test_rpc_coverage.py
@@ -10,7 +10,7 @@ Subordinate to issue #102 Slice 5 via issue #104.
 import asyncio
 import sys
 from collections.abc import Generator
-from typing import Any, cast
+from typing import Any
 
 import pytest
 
@@ -85,14 +85,14 @@ class TestSealedWorkerRPC:
             env={"PYISOLATE_SIGNAL_CLEANUP": "1"},
         )
 
-        ext = Extension(
+        ext: Extension[ReferenceTestExtension] = Extension(
             module_path=package_path,
             extension_type=ReferenceTestExtension,
             config=config,
             venv_root_path=str(host.venv_root),
         )
         ext.ensure_process_started()
-        host.extensions.append(cast(Any, ext))
+        host.extensions.append(ext)
 
         proxy = ext.get_proxy()
         result = _run(proxy.ping())

--- a/tests/integration_v2/test_rpc_coverage.py
+++ b/tests/integration_v2/test_rpc_coverage.py
@@ -9,13 +9,15 @@ Subordinate to issue #102 Slice 5 via issue #104.
 
 import asyncio
 import sys
+from collections.abc import Generator
+from typing import Any, cast
 
 import pytest
 
 from tests.harness.host import ReferenceHost
 
 
-def _run(coro):
+def _run(coro: Any) -> Any:
     loop = asyncio.new_event_loop()
     try:
         return loop.run_until_complete(coro)
@@ -24,7 +26,7 @@ def _run(coro):
 
 
 @pytest.fixture
-def host():
+def host() -> Generator[ReferenceHost, None, None]:
     h = ReferenceHost()
     try:
         h.setup()
@@ -35,7 +37,7 @@ def host():
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Extension loading requires Linux UDS")
 class TestTorchShareRPC:
-    def test_torch_share_singleton_roundtrip(self, host: ReferenceHost):
+    def test_torch_share_singleton_roundtrip(self, host: ReferenceHost) -> None:
         """Load a torch_share extension and verify RPC round-trip.
 
         Exercises AsyncRPC.run, _send_thread, _recv_thread, and
@@ -53,7 +55,7 @@ class TestTorchShareRPC:
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Extension loading requires Linux UDS")
 class TestSealedWorkerRPC:
-    def test_sealed_worker_singleton_roundtrip(self, host: ReferenceHost):
+    def test_sealed_worker_singleton_roundtrip(self, host: ReferenceHost) -> None:
         """Load a sealed_worker extension and verify RPC round-trip.
 
         Exercises the same RPC paths as torch_share but with
@@ -90,7 +92,7 @@ class TestSealedWorkerRPC:
             venv_root_path=str(host.venv_root),
         )
         ext.ensure_process_started()
-        host.extensions.append(ext)
+        host.extensions.append(cast(Any, ext))
 
         proxy = ext.get_proxy()
         result = _run(proxy.ping())
@@ -99,7 +101,7 @@ class TestSealedWorkerRPC:
 
 @pytest.mark.skipif(sys.platform != "linux", reason="bwrap requires Linux")
 class TestBwrapTorchShareRPC:
-    def test_bwrap_torch_share_roundtrip(self, host: ReferenceHost):
+    def test_bwrap_torch_share_roundtrip(self, host: ReferenceHost) -> None:
         """Load a bwrap + torch_share extension and verify RPC round-trip."""
         from pyisolate._internal.sandbox_detect import detect_sandbox_capability
 

--- a/tests/integration_v2/test_tensors.py
+++ b/tests/integration_v2/test_tensors.py
@@ -1,4 +1,5 @@
 import gc
+from typing import Any
 
 import pytest
 import torch  # noqa: E402
@@ -12,7 +13,7 @@ except ImportError:
 
 
 @pytest.mark.asyncio
-async def test_tensor_roundtrip_cpu(reference_host):
+async def test_tensor_roundtrip_cpu(reference_host: Any) -> None:
     """
     Verify sending a CPU tensor to the child and getting it back.
     """
@@ -38,7 +39,7 @@ async def test_tensor_roundtrip_cpu(reference_host):
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.asyncio
-async def test_cuda_allocation(reference_host):
+async def test_cuda_allocation(reference_host: Any) -> None:
     """
     Verify child can allocate CUDA memory and return meta-data.
     """
@@ -62,7 +63,7 @@ async def test_cuda_allocation(reference_host):
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.asyncio
-async def test_tensor_roundtrip_cuda(reference_host):
+async def test_tensor_roundtrip_cuda(reference_host: Any) -> None:
     """
     Verify sending a CUDA tensor. Requires CUDA IPC if isolated.
     """

--- a/tests/path_unification/test_path_helpers.py
+++ b/tests/path_unification/test_path_helpers.py
@@ -15,7 +15,7 @@ from pyisolate.path_helpers import (
 class TestSerializeHostSnapshot:
     """Tests for host environment snapshot capture."""
 
-    def test_snapshot_contains_required_keys(self):
+    def test_snapshot_contains_required_keys(self) -> None:
         """Snapshot must include sys.path, executable, prefix, and env vars."""
         snapshot = serialize_host_snapshot()
 
@@ -29,12 +29,12 @@ class TestSerializeHostSnapshot:
         assert isinstance(snapshot["sys_prefix"], str)
         assert isinstance(snapshot["environment"], dict)
 
-    def test_snapshot_captures_sys_path(self):
+    def test_snapshot_captures_sys_path(self) -> None:
         """sys_path in snapshot should match current sys.path."""
         snapshot = serialize_host_snapshot()
         assert snapshot["sys_path"] == list(sys.path)
 
-    def test_snapshot_writes_to_file(self):
+    def test_snapshot_writes_to_file(self) -> None:
         """When output_path provided, snapshot should be written as JSON."""
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = Path(tmpdir) / "snapshot.json"
@@ -47,13 +47,13 @@ class TestSerializeHostSnapshot:
             assert loaded["sys_path"] == snapshot["sys_path"]
             assert loaded["sys_executable"] == snapshot["sys_executable"]
 
-    def test_snapshot_without_file_returns_dict(self):
+    def test_snapshot_without_file_returns_dict(self) -> None:
         """When no output_path, should return dict without side effects."""
         snapshot = serialize_host_snapshot()
         assert isinstance(snapshot, dict)
         assert len(snapshot["sys_path"]) > 0
 
-    def test_snapshot_with_extra_env_keys(self):
+    def test_snapshot_with_extra_env_keys(self) -> None:
         """Should capture additional env vars when extra_env_keys provided."""
         # Set a test env var
         os.environ["TEST_PYISOLATE_VAR"] = "test_value"
@@ -71,10 +71,10 @@ class TestSerializeHostSnapshot:
 class TestBuildChildSysPath:
     """Tests for child sys.path reconstruction logic."""
 
-    def test_preserves_host_order(self):
+    def test_preserves_host_order(self) -> None:
         """Host paths must appear in original order."""
         host = ["/host/lib1", "/host/lib2", "/host/lib3"]
-        extras = ["/venv/lib"]
+        extras: list[str] = ["/venv/lib"]
 
         result = build_child_sys_path(host, extras)
 
@@ -82,7 +82,7 @@ class TestBuildChildSysPath:
         assert result[:3] == host
         assert result[3] == extras[0]
 
-    def test_removes_duplicates(self):
+    def test_removes_duplicates(self) -> None:
         """Duplicate paths should be removed while preserving first occurrence."""
         host = ["/host/lib", "/host/lib2", "/host/lib"]
         extras = ["/venv/lib"]
@@ -93,7 +93,7 @@ class TestBuildChildSysPath:
         assert result.count("/host/lib") == 1
         assert result[0] == "/host/lib"
 
-    def test_inserts_preferred_root_first_when_missing(self):
+    def test_inserts_preferred_root_first_when_missing(self) -> None:
         """If preferred_root provided and not in host_paths, prepend it."""
         host = ["/host/lib1", "/host/lib2"]
         extras = ["/venv/lib"]
@@ -104,7 +104,7 @@ class TestBuildChildSysPath:
         assert result[0] == preferred
         assert result[1:3] == host
 
-    def test_does_not_duplicate_preferred_root_if_present(self):
+    def test_does_not_duplicate_preferred_root_if_present(self) -> None:
         """If preferred_root already in host_paths, don't duplicate it."""
         preferred = "/myapp/root"
         host = [preferred, "/host/lib1"]
@@ -115,7 +115,7 @@ class TestBuildChildSysPath:
         assert result.count(preferred) == 1
         assert result[0] == preferred
 
-    def test_filtered_subdirs_removes_named_dirs_when_provided(self):
+    def test_filtered_subdirs_removes_named_dirs_when_provided(self) -> None:
         """Subdirectories in filtered_subdirs list should be excluded from output."""
         root = "/myapp/root"
         host = [f"{root}/comfy", f"{root}/app", "/host/lib"]
@@ -128,11 +128,11 @@ class TestBuildChildSysPath:
         assert f"{root}/app" not in result
         assert "/host/lib" in result
 
-    def test_filtered_subdirs_none_preserves_all_subdirectory_paths(self):
+    def test_filtered_subdirs_none_preserves_all_subdirectory_paths(self) -> None:
         """When filtered_subdirs is None, no subdirectory filtering is applied."""
         root = "/myapp/root"
         host = [f"{root}/utils", f"{root}/app", "/host/lib"]
-        extras = []
+        extras: list[str] = []
 
         result = build_child_sys_path(host, extras, root, filtered_subdirs=None)
 
@@ -141,12 +141,12 @@ class TestBuildChildSysPath:
         assert f"{root}/app" in result
         assert "/host/lib" in result
 
-    def test_filtered_subdirs_does_not_filter_deep_venv_paths(self):
+    def test_filtered_subdirs_does_not_filter_deep_venv_paths(self) -> None:
         """Paths deeper than one level under preferred_root are not filtered."""
         root = "/myapp/root"
         venv_site = f"{root}/.venv/lib/python3.12/site-packages"
         host = [f"{root}/comfy", venv_site, "/host/lib"]
-        extras = []
+        extras: list[str] = []
 
         result = build_child_sys_path(host, extras, root, filtered_subdirs=["comfy"])
 
@@ -154,7 +154,7 @@ class TestBuildChildSysPath:
         assert venv_site in result
         assert f"{root}/comfy" not in result
 
-    def test_appends_extra_paths(self):
+    def test_appends_extra_paths(self) -> None:
         """Extra paths (isolated venv) should be appended after host paths."""
         host = ["/host/lib"]
         extras = ["/venv/lib1", "/venv/lib2"]
@@ -164,30 +164,30 @@ class TestBuildChildSysPath:
         assert result[0] == host[0]
         assert result[1:] == extras
 
-    def test_handles_empty_host_paths(self):
+    def test_handles_empty_host_paths(self) -> None:
         """Should work with empty host paths (edge case)."""
-        host = []
+        host: list[str] = []
         extras = ["/venv/lib"]
 
         result = build_child_sys_path(host, extras)
 
         assert result == extras
 
-    def test_handles_empty_extra_paths(self):
+    def test_handles_empty_extra_paths(self) -> None:
         """Should work with empty extra paths."""
         host = ["/host/lib"]
-        extras = []
+        extras: list[str] = []
 
         result = build_child_sys_path(host, extras)
 
         assert result == host
 
-    def test_normalizes_paths_for_duplicate_detection(self):
+    def test_normalizes_paths_for_duplicate_detection(self) -> None:
         """Paths differing only in case/separators should be deduplicated."""
         # This test assumes case-insensitive filesystem (Windows-like)
         # On Linux it may not dedupe, which is correct behavior
         host = ["/Host/Lib", "/host/lib"]  # Different case
-        extras = []
+        extras: list[str] = []
 
         result = build_child_sys_path(host, extras)
 
@@ -195,7 +195,7 @@ class TestBuildChildSysPath:
         assert len(result) >= 1
         assert len(result) <= 2
 
-    def test_idempotent_with_repeated_extras(self):
+    def test_idempotent_with_repeated_extras(self) -> None:
         """Passing extras already in host should not duplicate."""
         host = ["/host/lib", "/venv/lib"]
         extras = ["/venv/lib"]  # Already in host
@@ -204,7 +204,7 @@ class TestBuildChildSysPath:
 
         assert result.count("/venv/lib") == 1
 
-    def test_handles_empty_string_paths(self):
+    def test_handles_empty_string_paths(self) -> None:
         """Empty string paths should be filtered out by add_path guard."""
         host = ["/host/lib", "", "/host/lib2"]
         extras = ["", "/venv/lib"]
@@ -221,7 +221,7 @@ class TestBuildChildSysPath:
 class TestIntegration:
     """Integration tests combining snapshot + path building."""
 
-    def test_round_trip_snapshot_and_rebuild(self):
+    def test_round_trip_snapshot_and_rebuild(self) -> None:
         """Capture snapshot, build child path, verify reconstruction."""
         with tempfile.TemporaryDirectory() as tmpdir:
             snapshot_path = Path(tmpdir) / "snapshot.json"

--- a/tests/test_adapter_contract.py
+++ b/tests/test_adapter_contract.py
@@ -8,7 +8,9 @@ The MockHostAdapter from fixtures serves as the reference implementation
 and is used to demonstrate expected behavior for each protocol method.
 """
 
-from pyisolate._internal.rpc_protocol import ProxiedSingleton
+from typing import cast
+
+from pyisolate._internal.rpc_protocol import AsyncRPC, ProxiedSingleton
 from pyisolate._internal.serialization_registry import SerializerRegistry
 from pyisolate.interfaces import IsolationAdapter
 
@@ -18,18 +20,18 @@ from .fixtures.test_adapter import MockHostAdapter, MockRegistry, MockTestData
 class TestAdapterIdentifier:
     """Tests for the identifier property."""
 
-    def test_adapter_has_identifier(self):
+    def test_adapter_has_identifier(self) -> None:
         """Adapter must have a non-empty identifier."""
         adapter = MockHostAdapter()
         assert adapter.identifier
         assert isinstance(adapter.identifier, str)
 
-    def test_identifier_is_lowercase(self):
+    def test_identifier_is_lowercase(self) -> None:
         """Identifier should be lowercase for consistency."""
         adapter = MockHostAdapter()
         assert adapter.identifier == adapter.identifier.lower()
 
-    def test_identifier_no_spaces(self):
+    def test_identifier_no_spaces(self) -> None:
         """Identifier should not contain spaces."""
         adapter = MockHostAdapter()
         assert " " not in adapter.identifier
@@ -38,7 +40,7 @@ class TestAdapterIdentifier:
 class TestAdapterPathConfig:
     """Tests for get_path_config method."""
 
-    def test_get_path_config_returns_dict(self):
+    def test_get_path_config_returns_dict(self) -> None:
         """get_path_config must return dict with required keys."""
         adapter = MockHostAdapter()
         config = adapter.get_path_config("/some/module/__init__.py")
@@ -47,7 +49,7 @@ class TestAdapterPathConfig:
         assert "preferred_root" in config
         assert "additional_paths" in config
 
-    def test_preferred_root_is_string(self):
+    def test_preferred_root_is_string(self) -> None:
         """preferred_root must be a string path."""
         adapter = MockHostAdapter("/tmp/myapp")
         config = adapter.get_path_config("/tmp/myapp/ext/__init__.py")
@@ -55,7 +57,7 @@ class TestAdapterPathConfig:
         assert isinstance(config["preferred_root"], str)
         assert config["preferred_root"] == "/tmp/myapp"
 
-    def test_additional_paths_is_list(self):
+    def test_additional_paths_is_list(self) -> None:
         """additional_paths must be a list of strings."""
         adapter = MockHostAdapter()
         config = adapter.get_path_config("/some/path")
@@ -68,7 +70,7 @@ class TestAdapterPathConfig:
 class TestAdapterSerializers:
     """Tests for register_serializers method."""
 
-    def test_register_serializers_accepts_registry(self):
+    def test_register_serializers_accepts_registry(self) -> None:
         """register_serializers must accept SerializerRegistryProtocol."""
         adapter = MockHostAdapter()
         registry = SerializerRegistry.get_instance()
@@ -77,7 +79,7 @@ class TestAdapterSerializers:
         # Should not raise
         adapter.register_serializers(registry)
 
-    def test_registered_serializer_is_callable(self):
+    def test_registered_serializer_is_callable(self) -> None:
         """Registered serializers must be callable."""
         adapter = MockHostAdapter()
         registry = SerializerRegistry.get_instance()
@@ -89,7 +91,7 @@ class TestAdapterSerializers:
         assert serializer is not None
         assert callable(serializer)
 
-    def test_serializer_produces_json_compatible(self):
+    def test_serializer_produces_json_compatible(self) -> None:
         """Serializer output must be JSON-compatible."""
         import json
 
@@ -100,6 +102,7 @@ class TestAdapterSerializers:
         adapter.register_serializers(registry)
 
         serializer = registry.get_serializer("MockTestData")
+        assert serializer is not None
         test_obj = MockTestData("hello")
         result = serializer(test_obj)
 
@@ -111,14 +114,14 @@ class TestAdapterSerializers:
 class TestAdapterRpcServices:
     """Tests for provide_rpc_services method."""
 
-    def test_provide_rpc_services_returns_list(self):
+    def test_provide_rpc_services_returns_list(self) -> None:
         """provide_rpc_services must return a list."""
         adapter = MockHostAdapter()
         services = adapter.provide_rpc_services()
 
         assert isinstance(services, list)
 
-    def test_services_are_proxied_singleton_subclasses(self):
+    def test_services_are_proxied_singleton_subclasses(self) -> None:
         """Each service must be a ProxiedSingleton subclass."""
         adapter = MockHostAdapter()
         services = adapter.provide_rpc_services()
@@ -127,7 +130,7 @@ class TestAdapterRpcServices:
             assert isinstance(svc, type), f"{svc} is not a class"
             assert issubclass(svc, ProxiedSingleton), f"{svc} is not a ProxiedSingleton"
 
-    def test_services_are_instantiable(self):
+    def test_services_are_instantiable(self) -> None:
         """Each service class must be instantiable with no args."""
         adapter = MockHostAdapter()
         services = adapter.provide_rpc_services()
@@ -141,13 +144,13 @@ class TestAdapterRpcServices:
 class TestAdapterApiRegistration:
     """Tests for handle_api_registration method."""
 
-    def test_handle_api_registration_accepts_args(self):
+    def test_handle_api_registration_accepts_args(self) -> None:
         """handle_api_registration must accept api and rpc args."""
         adapter = MockHostAdapter()
 
         # Create mock api and rpc
         api = MockRegistry()
-        rpc = None  # Could be a mock, but we just test it accepts the arg
+        rpc = cast(AsyncRPC, object())
 
         # Should not raise
         adapter.handle_api_registration(api, rpc)
@@ -156,14 +159,14 @@ class TestAdapterApiRegistration:
 class TestAdapterProtocolCompliance:
     """Tests that verify full protocol compliance."""
 
-    def test_adapter_implements_protocol(self):
+    def test_adapter_implements_protocol(self) -> None:
         """MockHostAdapter must implement IsolationAdapter protocol."""
         adapter = MockHostAdapter()
 
         # Protocol check (structural typing)
         assert isinstance(adapter, IsolationAdapter)
 
-    def test_adapter_is_runtime_checkable(self):
+    def test_adapter_is_runtime_checkable(self) -> None:
         """IsolationAdapter must be runtime checkable."""
         # This verifies the @runtime_checkable decorator is present
         adapter = MockHostAdapter()
@@ -173,7 +176,7 @@ class TestAdapterProtocolCompliance:
 class TestMockRegistryBehavior:
     """Tests for MockRegistry ProxiedSingleton example."""
 
-    def test_registry_register_returns_id(self):
+    def test_registry_register_returns_id(self) -> None:
         """register() must return a string ID."""
         registry = MockRegistry()
         obj_id = registry.register({"key": "value"})
@@ -181,7 +184,7 @@ class TestMockRegistryBehavior:
         assert isinstance(obj_id, str)
         assert obj_id.startswith("obj_")
 
-    def test_registry_get_retrieves_object(self):
+    def test_registry_get_retrieves_object(self) -> None:
         """get() must retrieve the registered object."""
         registry = MockRegistry()
         original = {"key": "value"}
@@ -190,14 +193,14 @@ class TestMockRegistryBehavior:
         retrieved = registry.get(obj_id)
         assert retrieved == original
 
-    def test_registry_get_unknown_returns_none(self):
+    def test_registry_get_unknown_returns_none(self) -> None:
         """get() with unknown ID must return None."""
         registry = MockRegistry()
 
         result = registry.get("nonexistent")
         assert result is None
 
-    def test_registry_clear_removes_all(self):
+    def test_registry_clear_removes_all(self) -> None:
         """clear() must remove all stored objects."""
         registry = MockRegistry()
         registry.register("obj1")
@@ -212,7 +215,7 @@ class TestMockRegistryBehavior:
 class TestTestDataSerialization:
     """Tests for TestData custom type serialization."""
 
-    def test_testdata_equality(self):
+    def test_testdata_equality(self) -> None:
         """TestData equality must compare values."""
         a = MockTestData("hello")
         b = MockTestData("hello")
@@ -221,7 +224,7 @@ class TestTestDataSerialization:
         assert a == b
         assert a != c
 
-    def test_testdata_serialization_roundtrip(self):
+    def test_testdata_serialization_roundtrip(self) -> None:
         """TestData must survive serialization roundtrip."""
         adapter = MockHostAdapter()
         registry = SerializerRegistry.get_instance()
@@ -232,6 +235,8 @@ class TestTestDataSerialization:
         original = MockTestData("test_value")
         serializer = registry.get_serializer("MockTestData")
         deserializer = registry.get_deserializer("MockTestData")
+        assert serializer is not None
+        assert deserializer is not None
 
         serialized = serializer(original)
         deserialized = deserializer(serialized)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,6 +1,8 @@
 import json
 import sys
+from collections.abc import Generator
 from importlib import import_module
+from typing import Any
 
 import pytest
 
@@ -11,36 +13,36 @@ from pyisolate._internal.serialization_registry import SerializerRegistry
 class FakeAdapter:
     identifier = "fake"
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.setup_called = False
         self.registry_used = False
 
-    def get_path_config(self, module_path):
+    def get_path_config(self, module_path: Any) -> Any:
         return None
 
-    def setup_child_environment(self, snapshot):
+    def setup_child_environment(self, snapshot: Any) -> None:
         self.setup_called = True
 
-    def register_serializers(self, registry):
+    def register_serializers(self, registry: Any) -> None:
         self.registry_used = True
         registry.register("FakeType", lambda x: {"v": x}, lambda x: x["v"])
 
-    def provide_rpc_services(self):
+    def provide_rpc_services(self) -> Any:
         return []
 
-    def handle_api_registration(self, api, rpc):
+    def handle_api_registration(self, api: Any, rpc: Any) -> Any:
         return None
 
 
 @pytest.fixture(autouse=True)
-def clear_registry():
+def clear_registry() -> Generator[None, None, None]:
     registry = SerializerRegistry.get_instance()
     registry.clear()
     yield
     registry.clear()
 
 
-def test_bootstrap_applies_snapshot(monkeypatch, tmp_path):
+def test_bootstrap_applies_snapshot(monkeypatch: Any, tmp_path: Any) -> None:
     fake_adapter = FakeAdapter()
     monkeypatch.setattr(bootstrap, "_rehydrate_adapter", lambda name: fake_adapter)
 
@@ -66,18 +68,18 @@ def test_bootstrap_applies_snapshot(monkeypatch, tmp_path):
     assert registry.has_handler("FakeType")
 
 
-def test_bootstrap_no_snapshot(monkeypatch):
+def test_bootstrap_no_snapshot(monkeypatch: Any) -> None:
     monkeypatch.delenv("PYISOLATE_HOST_SNAPSHOT", raising=False)
     assert bootstrap.bootstrap_child() is None
 
 
-def test_bootstrap_bad_json(monkeypatch):
+def test_bootstrap_bad_json(monkeypatch: Any) -> None:
     monkeypatch.setenv("PYISOLATE_HOST_SNAPSHOT", "not-json")
     with pytest.raises(ValueError):
         bootstrap.bootstrap_child()
 
 
-def test_bootstrap_missing_adapter(monkeypatch):
+def test_bootstrap_missing_adapter(monkeypatch: Any) -> None:
     monkeypatch.setenv("PYISOLATE_HOST_SNAPSHOT", json.dumps({"adapter_ref": "missing"}))
     monkeypatch.setattr(
         bootstrap, "_rehydrate_adapter", lambda name: (_ for _ in ()).throw(ValueError("nope"))
@@ -86,7 +88,7 @@ def test_bootstrap_missing_adapter(monkeypatch):
         bootstrap.bootstrap_child()
 
 
-def test_bootstrap_skips_host_sys_path_for_sealed_worker(monkeypatch, tmp_path):
+def test_bootstrap_skips_host_sys_path_for_sealed_worker(monkeypatch: Any, tmp_path: Any) -> None:
     host_only_path = str(tmp_path / "host_only")
     snapshot = {
         "sys_path": [host_only_path],
@@ -106,7 +108,7 @@ def test_bootstrap_skips_host_sys_path_for_sealed_worker(monkeypatch, tmp_path):
     assert host_only_path not in updated_sys_path
 
 
-def test_bootstrap_sealed_worker_skips_adapter_rehydration(monkeypatch):
+def test_bootstrap_sealed_worker_skips_adapter_rehydration(monkeypatch: Any) -> None:
     snapshot = {
         "adapter_ref": "bad.module:BadClass",
         "apply_host_sys_path": False,
@@ -119,7 +121,9 @@ def test_bootstrap_sealed_worker_skips_adapter_rehydration(monkeypatch):
     assert bootstrap.bootstrap_child() is None
 
 
-def test_sealed_worker_host_policy_ro_paths_enable_import_without_host_sys_path(monkeypatch, tmp_path):
+def test_sealed_worker_host_policy_ro_paths_enable_import_without_host_sys_path(
+    monkeypatch: Any, tmp_path: Any
+) -> None:
     module_name = "sealed_opt_in_visible_module"
     module_root = tmp_path / "opt_in_root"
     module_root.mkdir(parents=True, exist_ok=True)
@@ -143,7 +147,7 @@ def test_sealed_worker_host_policy_ro_paths_enable_import_without_host_sys_path(
     assert imported.VALUE == 42
 
 
-def test_sealed_worker_without_opt_in_still_cannot_import_module(monkeypatch, tmp_path):
+def test_sealed_worker_without_opt_in_still_cannot_import_module(monkeypatch: Any, tmp_path: Any) -> None:
     module_name = "sealed_no_opt_in_hidden_module"
     blocked_root = tmp_path / "blocked_root"
     blocked_root.mkdir(parents=True, exist_ok=True)
@@ -165,7 +169,7 @@ def test_sealed_worker_without_opt_in_still_cannot_import_module(monkeypatch, tm
         sys.modules.pop(module_name, None)
 
 
-def test_sealed_worker_attempts_adapter_rehydration_non_fatal(monkeypatch, tmp_path):
+def test_sealed_worker_attempts_adapter_rehydration_non_fatal(monkeypatch: Any, tmp_path: Any) -> None:
     """Sealed workers attempt adapter rehydration for serializer registration.
 
     If rehydration fails, it is not fatal — the sealed worker continues
@@ -179,7 +183,7 @@ def test_sealed_worker_attempts_adapter_rehydration_non_fatal(monkeypatch, tmp_p
 
     called = {"rehydrate": False}
 
-    def _fail(_name: str):
+    def _fail(_name: str) -> None:
         called["rehydrate"] = True
         raise ImportError("adapter module not available in sealed env")
 
@@ -205,11 +209,11 @@ def test_sealed_worker_attempts_adapter_rehydration_non_fatal(monkeypatch, tmp_p
     assert imported.VALUE == 99
 
 
-def test_sealed_worker_singleton_bootstrap_attempts_adapter_rehydration(monkeypatch):
+def test_sealed_worker_singleton_bootstrap_attempts_adapter_rehydration(monkeypatch: Any) -> None:
     """Sealed workers attempt adapter rehydration. Failure is non-fatal."""
     called = {"rehydrate": False}
 
-    def _fail(_name: str):
+    def _fail(_name: str) -> None:
         called["rehydrate"] = True
         raise ImportError("sealed singleton cannot import adapter module")
 

--- a/tests/test_bootstrap_additional.py
+++ b/tests/test_bootstrap_additional.py
@@ -1,12 +1,13 @@
 import json
 import sys
+from typing import Any
 
 import pytest
 
 from pyisolate._internal import bootstrap
 
 
-def test_apply_sys_path_merges_and_dedup(monkeypatch, tmp_path):
+def test_apply_sys_path_merges_and_dedup(monkeypatch: Any, tmp_path: Any) -> None:
     original = list(sys.path)
     snapshot = {
         "sys_path": [str(tmp_path), str(tmp_path)],
@@ -20,12 +21,12 @@ def test_apply_sys_path_merges_and_dedup(monkeypatch, tmp_path):
     sys.path[:] = original
 
 
-def test_bootstrap_child_missing_snapshot_returns_none(monkeypatch):
+def test_bootstrap_child_missing_snapshot_returns_none(monkeypatch: Any) -> None:
     monkeypatch.delenv("PYISOLATE_HOST_SNAPSHOT", raising=False)
     assert bootstrap.bootstrap_child() is None
 
 
-def test_bootstrap_child_json_payload_adapter_none(monkeypatch):
+def test_bootstrap_child_json_payload_adapter_none(monkeypatch: Any) -> None:
     payload = json.dumps(
         {
             "sys_path": [],
@@ -41,7 +42,7 @@ def test_bootstrap_child_json_payload_adapter_none(monkeypatch):
         bootstrap.bootstrap_child()
 
 
-def test_bootstrap_child_snapshot_file_errors(tmp_path, monkeypatch):
+def test_bootstrap_child_snapshot_file_errors(tmp_path: Any, monkeypatch: Any) -> None:
     snap_path = tmp_path / "bad.json"
     snap_path.write_text("not-json")
     monkeypatch.setenv("PYISOLATE_HOST_SNAPSHOT", str(snap_path))
@@ -49,7 +50,7 @@ def test_bootstrap_child_snapshot_file_errors(tmp_path, monkeypatch):
         bootstrap.bootstrap_child()
 
 
-def test_bootstrap_child_missing_file_graceful(tmp_path, monkeypatch):
+def test_bootstrap_child_missing_file_graceful(tmp_path: Any, monkeypatch: Any) -> None:
     snap_path = tmp_path / "missing.json"
     monkeypatch.setenv("PYISOLATE_HOST_SNAPSHOT", str(snap_path))
     assert bootstrap.bootstrap_child() is None

--- a/tests/test_client_entrypoint_extra.py
+++ b/tests/test_client_entrypoint_extra.py
@@ -228,10 +228,12 @@ def test_sealed_worker_skips_api_class_import(monkeypatch: Any) -> Any:
         },
     )
 
-    def _forbidden_import(name: str, package: str | None = None) -> Any:  # noqa: ARG001
+    real_import_module = importlib.import_module
+
+    def _forbidden_import(name: str, package: str | None = None) -> Any:
         if name == "forbidden.module":
             raise AssertionError("sealed worker must not import API classes from config")
-        return importlib.import_module(name)
+        return real_import_module(name, package)
 
     monkeypatch.setattr(importlib, "import_module", _forbidden_import)
 

--- a/tests/test_client_entrypoint_extra.py
+++ b/tests/test_client_entrypoint_extra.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 from types import ModuleType
+from typing import Any, cast
 
 import pytest
 
@@ -11,7 +12,7 @@ from pyisolate.shared import ExtensionBase
 
 
 class DummyExtension(ExtensionBase):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.before_called = False
         self.loaded_called = False
@@ -25,13 +26,14 @@ class DummyExtension(ExtensionBase):
 
 
 @pytest.mark.asyncio
-async def test_async_entrypoint_runs_hooks_and_registers(tmp_path, monkeypatch):
+async def test_async_entrypoint_runs_hooks_and_registers(tmp_path: Any, monkeypatch: Any) -> Any:
     module_dir = tmp_path / "ext"
     module_dir.mkdir()
     (module_dir / "__init__.py").write_text("VALUE = 42\n")
 
     config: ExtensionConfig = {
         "name": "demo",
+        "isolated": True,
         "dependencies": [],
         "share_torch": False,
         "share_cuda_ipc": False,
@@ -39,17 +41,17 @@ async def test_async_entrypoint_runs_hooks_and_registers(tmp_path, monkeypatch):
     }
 
     class FakeRPC:
-        def __init__(self, recv_queue=None, send_queue=None):  # noqa: ARG002
-            self.registered = []
+        def __init__(self, recv_queue: Any = None, send_queue: Any = None) -> None:  # noqa: ARG002
+            self.registered: list[tuple[Any, Any]] = []
             self.running = False
 
-        def register_callee(self, obj, object_id):
+        def register_callee(self, obj: Any, object_id: Any) -> None:
             self.registered.append((obj, object_id))
 
-        def run(self):
+        def run(self) -> None:
             self.running = True
 
-        async def run_until_stopped(self):
+        async def run_until_stopped(self) -> Any:
             return None
 
     monkeypatch.setattr(client, "AsyncRPC", FakeRPC)
@@ -70,9 +72,10 @@ async def test_async_entrypoint_runs_hooks_and_registers(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_async_entrypoint_rejects_missing_dir(tmp_path):
+async def test_async_entrypoint_rejects_missing_dir(tmp_path: Any) -> None:
     config: ExtensionConfig = {
         "name": "demo",
+        "isolated": True,
         "dependencies": [],
         "share_torch": False,
         "share_cuda_ipc": False,
@@ -92,7 +95,7 @@ async def test_async_entrypoint_rejects_missing_dir(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_async_entrypoint_uses_inference_mode(monkeypatch, tmp_path):
+async def test_async_entrypoint_uses_inference_mode(monkeypatch: Any, tmp_path: Any) -> Any:
     module_dir = tmp_path / "ext2"
     module_dir.mkdir()
     (module_dir / "__init__.py").write_text("VALUE = 1\n")
@@ -100,21 +103,22 @@ async def test_async_entrypoint_uses_inference_mode(monkeypatch, tmp_path):
     entered = {"count": 0}
 
     class DummyInference:
-        def __enter__(self):
+        def __enter__(self) -> Any:
             entered["count"] += 1
             return self
 
-        def __exit__(self, exc_type, exc, tb):  # noqa: ANN001
+        def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:  # noqa: ANN001
             return False
 
     class DummyTorch:
-        def inference_mode(self):
+        def inference_mode(self) -> Any:
             return DummyInference()
 
     monkeypatch.setitem(sys.modules, "torch", DummyTorch())
 
     config: ExtensionConfig = {
         "name": "demo2",
+        "isolated": True,
         "dependencies": [],
         "share_torch": True,
         "share_cuda_ipc": False,
@@ -122,16 +126,16 @@ async def test_async_entrypoint_uses_inference_mode(monkeypatch, tmp_path):
     }
 
     class FakeRPC:
-        def __init__(self, recv_queue=None, send_queue=None):  # noqa: ARG002
+        def __init__(self, recv_queue: Any = None, send_queue: Any = None) -> None:  # noqa: ARG002
             pass
 
-        def register_callee(self, *_):
+        def register_callee(self, *_: Any) -> Any:
             return None
 
-        def run(self):
+        def run(self) -> Any:
             return None
 
-        async def run_until_stopped(self):
+        async def run_until_stopped(self) -> Any:
             return None
 
     monkeypatch.setattr(client, "AsyncRPC", FakeRPC)
@@ -150,43 +154,46 @@ async def test_async_entrypoint_uses_inference_mode(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_async_entrypoint_registers_apis_with_adapter(monkeypatch, tmp_path):
+async def test_async_entrypoint_registers_apis_with_adapter(monkeypatch: Any, tmp_path: Any) -> Any:
     module_dir = tmp_path / "ext3"
     module_dir.mkdir()
     (module_dir / "__init__.py").write_text("VALUE = 3\n")
 
     class DummyAPI(ProxiedSingleton):
+        last_rpc: Any = None
+
         @classmethod
-        def use_remote(cls, rpc):  # noqa: ANN001
+        def use_remote(cls, rpc: Any) -> None:  # noqa: ANN001
             cls.last_rpc = rpc
 
     class DummyAdapter:
-        def __init__(self):
-            self.calls = []
+        def __init__(self) -> None:
+            self.calls: list[tuple[Any, Any]] = []
 
-        def handle_api_registration(self, api_instance, rpc):
+        def handle_api_registration(self, api_instance: Any, rpc: Any) -> None:
             self.calls.append((api_instance, rpc))
 
     dummy_adapter = DummyAdapter()
     monkeypatch.setattr(client, "_adapter", dummy_adapter)
 
     class FakeRPC:
-        def __init__(self, recv_queue=None, send_queue=None):  # noqa: ARG002
+        def __init__(self, recv_queue: Any = None, send_queue: Any = None) -> None:  # noqa: ARG002
             pass
 
-        def register_callee(self, *_):
+        def register_callee(self, *_: Any) -> Any:
             return None
 
-        def run(self):
+        def run(self) -> Any:
             return None
 
-        async def run_until_stopped(self):
+        async def run_until_stopped(self) -> Any:
             return None
 
     monkeypatch.setattr(client, "AsyncRPC", FakeRPC)
 
     config: ExtensionConfig = {
         "name": "demo3",
+        "isolated": True,
         "dependencies": [],
         "share_torch": False,
         "share_cuda_ipc": False,
@@ -207,17 +214,21 @@ async def test_async_entrypoint_registers_apis_with_adapter(monkeypatch, tmp_pat
     assert dummy_adapter.calls
 
 
-def test_sealed_worker_skips_api_class_import(monkeypatch):
-    config = {
-        "name": "demo-sealed",
-        "dependencies": [],
-        "share_torch": False,
-        "share_cuda_ipc": False,
-        "execution_model": "sealed_worker",
-        "apis": ["forbidden.module.ForbiddenAPI"],
-    }
+def test_sealed_worker_skips_api_class_import(monkeypatch: Any) -> Any:
+    config = cast(
+        ExtensionConfig,
+        {
+            "name": "demo-sealed",
+            "isolated": True,
+            "dependencies": [],
+            "share_torch": False,
+            "share_cuda_ipc": False,
+            "execution_model": "sealed_worker",
+            "apis": ["forbidden.module.ForbiddenAPI"],
+        },
+    )
 
-    def _forbidden_import(name: str, package: str | None = None):  # noqa: ARG001
+    def _forbidden_import(name: str, package: str | None = None) -> Any:  # noqa: ARG001
         if name == "forbidden.module":
             raise AssertionError("sealed worker must not import API classes from config")
         return importlib.import_module(name)

--- a/tests/test_conda_integration.py
+++ b/tests/test_conda_integration.py
@@ -9,11 +9,13 @@ import shutil
 import site
 import uuid
 from pathlib import Path
+from typing import cast
 
 import pytest
 import torch  # noqa: E402
 
 from pyisolate._internal.host import Extension  # noqa: E402
+from pyisolate.config import ExtensionConfig  # noqa: E402
 from pyisolate.sealed import SealedNodeExtension  # noqa: E402
 
 PIXI_AVAILABLE = shutil.which("pixi") is not None
@@ -34,26 +36,29 @@ def _shm_snapshot() -> set[str]:
     return {path.name for path in shm_root.glob("torch_*")}
 
 
-def _build_conda_config(fixture_path: Path, run_dir: Path) -> dict:
+def _build_conda_config(fixture_path: Path, run_dir: Path) -> ExtensionConfig:
     # Inlined from fixtures/conda_sealed_node/pyproject.toml — no TOML parser needed.
-    return {
-        "name": "conda-sealed-node",
-        "module_path": str(fixture_path),
-        "isolated": True,
-        "dependencies": ["packaging"],
-        "apis": [],
-        "env": {
-            "PYISOLATE_ARTIFACT_DIR": str(run_dir / "artifacts"),
-            "PYISOLATE_SIGNAL_CLEANUP": "1",
+    return cast(
+        ExtensionConfig,
+        {
+            "name": "conda-sealed-node",
+            "module_path": str(fixture_path),
+            "isolated": True,
+            "dependencies": ["packaging"],
+            "apis": [],
+            "env": {
+                "PYISOLATE_ARTIFACT_DIR": str(run_dir / "artifacts"),
+                "PYISOLATE_SIGNAL_CLEANUP": "1",
+            },
+            "share_torch": False,
+            "share_cuda_ipc": False,
+            "sandbox": {"writable_paths": [str(run_dir / "artifacts")]},
+            "package_manager": "conda",
+            "execution_model": "sealed_worker",
+            "conda_channels": ["conda-forge"],
+            "conda_dependencies": ["boltons", "numpy"],
         },
-        "share_torch": False,
-        "share_cuda_ipc": False,
-        "sandbox": {"writable_paths": [str(run_dir / "artifacts")]},
-        "package_manager": "conda",
-        "execution_model": "sealed_worker",
-        "conda_channels": ["conda-forge"],
-        "conda_dependencies": ["boltons"],
-    }
+    )
 
 
 @pytest.mark.asyncio
@@ -108,7 +113,7 @@ async def test_conda_sealed_runtime_avoids_host_path_leakage() -> None:
         shm_after = _shm_snapshot()
 
         assert torch.equal(echoed_tensor, input_tensor)
-        assert saw_json_tensor is True
+        assert saw_json_tensor is False
         launch_args = " ".join(str(part) for part in ext.proc.args)
         if os.name != "nt":
             assert shm_after == shm_before

--- a/tests/test_conda_integration.py
+++ b/tests/test_conda_integration.py
@@ -62,7 +62,9 @@ def _build_conda_config(fixture_path: Path, run_dir: Path) -> ExtensionConfig:
 
 
 @pytest.mark.asyncio
+@pytest.mark.network
 async def test_conda_sealed_runtime_avoids_host_path_leakage() -> None:
+    """Networked conda integration test; expected slow (~30s)."""
     fixture_path = Path(__file__).resolve().parent / "fixtures" / "conda_sealed_node"
     run_root = Path(__file__).resolve().parent.parent / ".pytest_artifacts" / "conda_integration"
     run_dir = run_root / uuid.uuid4().hex

--- a/tests/test_conda_sealed_worker_contract.py
+++ b/tests/test_conda_sealed_worker_contract.py
@@ -7,6 +7,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,11 +16,12 @@ from pyisolate._internal import bootstrap
 from pyisolate._internal.environment_conda import _generate_pixi_toml, _resolve_pixi_python
 from pyisolate._internal.host import Extension
 from pyisolate._internal.sandbox_detect import RestrictionModel
+from pyisolate.config import ExtensionConfig
 from pyisolate.shared import ExtensionBase
 
 
-def _make_conda_config(**overrides):
-    config = {
+def _make_conda_config(**overrides: Any) -> ExtensionConfig:
+    config: dict[str, Any] = {
         "name": "contract_ext",
         "module": "contract_module",
         "dependencies": ["requests>=2.0"],
@@ -31,10 +33,10 @@ def _make_conda_config(**overrides):
         "conda_platforms": ["linux-64"],
     }
     config.update(overrides)
-    return config
+    return config  # type: ignore[return-value]
 
 
-def _make_extension(config: dict) -> Extension:
+def _make_extension(config: ExtensionConfig) -> Extension:
     ext = Extension.__new__(Extension)
     ext.name = config["name"]
     ext.config = config
@@ -48,7 +50,7 @@ def _make_extension(config: dict) -> Extension:
     return ext
 
 
-def _capture_bootstrap_payload(config: dict) -> dict:
+def _capture_bootstrap_payload(config: ExtensionConfig) -> dict[str, Any]:
     ext = _make_extension(config)
 
     listener = MagicMock()
@@ -91,10 +93,10 @@ def _capture_bootstrap_payload(config: dict) -> dict:
         mock_socket.SOCK_STREAM = 1
         ext._launch_with_uds()
 
-    return transport.send.call_args[0][0]
+    return transport.send.call_args[0][0]  # type: ignore[no-any-return]
 
 
-def test_conda_dependency_split():
+def test_conda_dependency_split() -> None:
     config = _make_conda_config(
         conda_dependencies=["numpy>=1.26", "scipy"],
         dependencies=["requests>=2.0", "pandas"],
@@ -110,7 +112,7 @@ def test_conda_dependency_split():
     assert 'pandas = "*"' in toml_text
 
 
-def test_conda_channels_platforms_pass_through():
+def test_conda_channels_platforms_pass_through() -> None:
     config = _make_conda_config(
         conda_channels=["conda-forge", "nvidia"],
         conda_platforms=["linux-64", "win-64"],
@@ -122,7 +124,7 @@ def test_conda_channels_platforms_pass_through():
     assert 'platforms = ["linux-64", "win-64"]' in toml_text
 
 
-def test_uv_defaults_unchanged():
+def test_uv_defaults_unchanged() -> None:
     config = _make_conda_config(package_manager="uv")
     ext = _make_extension(config)
 
@@ -130,7 +132,7 @@ def test_uv_defaults_unchanged():
     assert ext._tensor_transport_mode() == "shared_memory"
 
 
-def test_no_host_fallback(tmp_path: Path):
+def test_no_host_fallback(tmp_path: Path) -> None:
     env_path = tmp_path / "conda_env"
     if os.name == "nt":
         python_path = env_path / ".pixi" / "envs" / "default" / "python.exe"
@@ -145,7 +147,7 @@ def test_no_host_fallback(tmp_path: Path):
     assert ".pixi" in str(resolved)
 
 
-def test_no_host_sys_path():
+def test_no_host_sys_path() -> None:
     payload = _capture_bootstrap_payload(
         _make_conda_config(package_manager="conda", execution_model="sealed_worker")
     )
@@ -156,7 +158,7 @@ def test_no_host_sys_path():
     assert snapshot["preferred_root"] is None
 
 
-def test_no_extension_wrapper_import():
+def test_no_extension_wrapper_import() -> None:
     payload = _capture_bootstrap_payload(
         _make_conda_config(package_manager="conda", execution_model="sealed_worker")
     )
@@ -169,7 +171,7 @@ def test_no_extension_wrapper_import():
 
 def test_sealed_worker_host_policy_ro_paths_default_block_and_opt_in_allow(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-):
+) -> None:
     payload_default = _capture_bootstrap_payload(
         _make_conda_config(package_manager="conda", execution_model="sealed_worker")
     )

--- a/tests/test_config_conda.py
+++ b/tests/test_config_conda.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -9,7 +10,7 @@ import pytest
 from pyisolate._internal.environment import validate_backend_config
 
 
-def _make_config(**overrides):
+def _make_config(**overrides: Any) -> Any:
     """Build a minimal ExtensionConfig dict with conda defaults."""
     base = {
         "name": "test_ext",
@@ -29,7 +30,7 @@ def _make_config(**overrides):
 
 
 class TestDefaultPackageManager:
-    def test_default_package_manager_is_uv(self):
+    def test_default_package_manager_is_uv(self) -> None:
         """Config without package_manager should default to 'uv' and pass validation."""
         config = _make_config()
         del config["package_manager"]
@@ -38,7 +39,7 @@ class TestDefaultPackageManager:
 
 
 class TestCondaShareTorchRaises:
-    def test_conda_share_torch_raises(self):
+    def test_conda_share_torch_raises(self) -> None:
         """conda + share_torch=True must raise ValueError."""
         config = _make_config(
             package_manager="conda",
@@ -50,8 +51,8 @@ class TestCondaShareTorchRaises:
 
 
 class TestCondaCudaWheelsAllowed:
-    @patch("shutil.which", return_value="/usr/bin/pixi")
-    def test_conda_cuda_wheels_allowed(self, _mock_which):
+    @patch("pyisolate._internal.pixi_provisioner.ensure_pixi", return_value="/usr/bin/pixi")
+    def test_conda_cuda_wheels_allowed(self, _mock_ensure_pixi: Any) -> None:
         """conda + cuda_wheels is valid — pixi resolves via [pypi-options]."""
         config = _make_config(
             package_manager="conda",
@@ -63,7 +64,7 @@ class TestCondaCudaWheelsAllowed:
 
 
 class TestCondaMissingChannelsRaises:
-    def test_conda_missing_channels_raises(self):
+    def test_conda_missing_channels_raises(self) -> None:
         """conda + empty/missing conda_channels must raise ValueError."""
         config = _make_config(
             package_manager="conda",
@@ -71,7 +72,7 @@ class TestCondaMissingChannelsRaises:
         with pytest.raises(ValueError, match="conda_channels"):
             validate_backend_config(config)
 
-    def test_conda_empty_channels_raises(self):
+    def test_conda_empty_channels_raises(self) -> None:
         """conda + empty conda_channels list must raise ValueError."""
         config = _make_config(
             package_manager="conda",
@@ -82,20 +83,25 @@ class TestCondaMissingChannelsRaises:
 
 
 class TestCondaMissingPixiRaises:
-    @patch("shutil.which", return_value=None)
-    def test_conda_missing_pixi_raises(self, mock_which):
-        """conda + pixi not on PATH must raise ValueError."""
+    @patch(
+        "pyisolate._internal.pixi_provisioner.ensure_pixi",
+        side_effect=RuntimeError("pixi bootstrap failed"),
+    )
+    def test_conda_missing_pixi_raises(self, mock_ensure_pixi: Any) -> None:
+        """conda + failed pixi bootstrap must raise ValueError."""
         config = _make_config(
             package_manager="conda",
             conda_channels=["conda-forge"],
         )
-        with pytest.raises(ValueError, match="pixi is required"):
+        with pytest.raises(
+            ValueError, match="pixi is required for conda backend but could not be provisioned"
+        ):
             validate_backend_config(config)
 
 
 class TestCondaValidConfigPasses:
-    @patch("shutil.which", return_value="/usr/bin/pixi")
-    def test_conda_valid_config_passes(self, mock_which):
+    @patch("pyisolate._internal.pixi_provisioner.ensure_pixi", return_value="/usr/bin/pixi")
+    def test_conda_valid_config_passes(self, mock_ensure_pixi: Any) -> None:
         """Valid conda config must pass validation without error."""
         config = _make_config(
             package_manager="conda",
@@ -105,8 +111,8 @@ class TestCondaValidConfigPasses:
         # Should not raise
         validate_backend_config(config)
 
-    @patch("shutil.which", return_value="/usr/bin/pixi")
-    def test_conda_with_platforms_passes(self, mock_which):
+    @patch("pyisolate._internal.pixi_provisioner.ensure_pixi", return_value="/usr/bin/pixi")
+    def test_conda_with_platforms_passes(self, mock_ensure_pixi: Any) -> None:
         """Valid conda config with platforms must pass."""
         config = _make_config(
             package_manager="conda",

--- a/tests/test_config_sealed_worker.py
+++ b/tests/test_config_sealed_worker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -9,7 +10,7 @@ import pytest
 from pyisolate._internal.environment import validate_backend_config
 
 
-def _make_config(**overrides):
+def _make_config(**overrides: Any) -> Any:
     base = {
         "name": "test_ext",
         "module_path": "/fake/path",
@@ -52,7 +53,9 @@ def test_sealed_worker_rejects_share_torch_true() -> None:
     ],
 )
 @patch("shutil.which", return_value="/usr/bin/pixi")
-def test_rejects_cuda_ipc_without_share_torch(mock_which, package_manager: str, execution_model: str) -> None:
+def test_rejects_cuda_ipc_without_share_torch(
+    mock_which: Any, package_manager: str, execution_model: str
+) -> None:
     config = _make_config(
         package_manager=package_manager,
         execution_model=execution_model,
@@ -65,8 +68,8 @@ def test_rejects_cuda_ipc_without_share_torch(mock_which, package_manager: str, 
         validate_backend_config(config)
 
 
-@patch("shutil.which", return_value="/usr/bin/pixi")
-def test_accepts_valid_mode_matrix(mock_which) -> None:
+@patch("pyisolate._internal.pixi_provisioner.ensure_pixi", return_value="/usr/bin/pixi")
+def test_accepts_valid_mode_matrix(mock_ensure_pixi: Any) -> None:
     valid_configs = [
         _make_config(execution_model="host-coupled", share_torch=True, share_cuda_ipc=True),
         _make_config(execution_model="host-coupled", share_torch=True, share_cuda_ipc=False),
@@ -112,8 +115,8 @@ def test_sealed_host_ro_paths_defaults_off_and_validation() -> None:
         validate_backend_config(relative)
 
 
-@patch("shutil.which", return_value="/usr/bin/pixi")
-def test_conda_defaults_to_sealed_worker(mock_which) -> None:
+@patch("pyisolate._internal.pixi_provisioner.ensure_pixi", return_value="/usr/bin/pixi")
+def test_conda_defaults_to_sealed_worker(mock_ensure_pixi: Any) -> None:
     config = _make_config(
         package_manager="conda",
         conda_channels=["conda-forge"],
@@ -123,7 +126,7 @@ def test_conda_defaults_to_sealed_worker(mock_which) -> None:
 
 
 @patch("shutil.which", return_value="/usr/bin/pixi")
-def test_conda_rejects_host_coupled_execution_model(mock_which) -> None:
+def test_conda_rejects_host_coupled_execution_model(mock_which: Any) -> None:
     config = _make_config(
         package_manager="conda",
         execution_model="host-coupled",

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -5,8 +5,7 @@ These tests verify configuration validation without spawning processes.
 
 from pathlib import Path
 
-from pyisolate import ExtensionConfig, ExtensionManagerConfig
-from pyisolate._internal.rpc_protocol import ProxiedSingleton
+from pyisolate import ExtensionConfig, ExtensionManagerConfig, ProxiedSingleton
 
 
 class TestExtensionManagerConfig:

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -12,7 +12,7 @@ from pyisolate._internal.rpc_protocol import ProxiedSingleton
 class TestExtensionManagerConfig:
     """Tests for ExtensionManagerConfig TypedDict."""
 
-    def test_minimal_config(self, tmp_path: Path):
+    def test_minimal_config(self, tmp_path: Path) -> None:
         """Minimal config requires only venv_root_path."""
         config: ExtensionManagerConfig = {
             "venv_root_path": str(tmp_path / "venvs"),
@@ -20,7 +20,7 @@ class TestExtensionManagerConfig:
 
         assert "venv_root_path" in config
 
-    def test_venv_root_path_is_string(self, tmp_path: Path):
+    def test_venv_root_path_is_string(self, tmp_path: Path) -> None:
         """venv_root_path must be a string path."""
         config: ExtensionManagerConfig = {
             "venv_root_path": str(tmp_path / "venvs"),
@@ -32,7 +32,7 @@ class TestExtensionManagerConfig:
 class TestExtensionConfigValidation:
     """Tests for ExtensionConfig field validation."""
 
-    def test_name_must_be_nonempty(self):
+    def test_name_must_be_nonempty(self) -> None:
         """Extension name should not be empty."""
         config: ExtensionConfig = {
             "name": "",  # Invalid but TypedDict doesn't enforce
@@ -48,7 +48,7 @@ class TestExtensionConfigValidation:
         # empty name would cause issues. Runtime validation needed.
         assert config["name"] == ""
 
-    def test_module_path_can_be_relative(self):
+    def test_module_path_can_be_relative(self) -> None:
         """Module path can be relative."""
         config: ExtensionConfig = {
             "name": "myext",
@@ -62,7 +62,7 @@ class TestExtensionConfigValidation:
 
         assert config["module_path"] == "./extensions/myext"
 
-    def test_module_path_can_be_absolute(self):
+    def test_module_path_can_be_absolute(self) -> None:
         """Module path can be absolute."""
         config: ExtensionConfig = {
             "name": "myext",
@@ -76,7 +76,7 @@ class TestExtensionConfigValidation:
 
         assert config["module_path"] == "/app/extensions/myext"
 
-    def test_dependencies_format(self):
+    def test_dependencies_format(self) -> None:
         """Dependencies are pip requirement specifiers."""
         config: ExtensionConfig = {
             "name": "myext",
@@ -95,7 +95,7 @@ class TestExtensionConfigValidation:
         assert len(config["dependencies"]) == 3
         assert "numpy>=1.20" in config["dependencies"]
 
-    def test_apis_are_singleton_types(self):
+    def test_apis_are_singleton_types(self) -> None:
         """APIs list contains ProxiedSingleton subclasses."""
 
         class MyService(ProxiedSingleton):
@@ -114,7 +114,7 @@ class TestExtensionConfigValidation:
         assert MyService in config["apis"]
         assert issubclass(config["apis"][0], ProxiedSingleton)
 
-    def test_share_torch_implies_requirements(self):
+    def test_share_torch_implies_requirements(self) -> None:
         """share_torch=True has implications for tensor handling."""
         config: ExtensionConfig = {
             "name": "ml_ext",
@@ -130,7 +130,7 @@ class TestExtensionConfigValidation:
         # share_cuda_ipc can be independently configured
         assert config["share_cuda_ipc"] is False
 
-    def test_share_cuda_ipc_requires_share_torch(self):
+    def test_share_cuda_ipc_requires_share_torch(self) -> None:
         """share_cuda_ipc only makes sense with share_torch."""
         # This is a semantic constraint, not enforced by TypedDict
         config: ExtensionConfig = {
@@ -150,7 +150,7 @@ class TestExtensionConfigValidation:
 class TestConfigDefaults:
     """Tests documenting expected config defaults."""
 
-    def test_isolated_defaults_true(self):
+    def test_isolated_defaults_true(self) -> None:
         """When creating configs, isolated typically defaults True."""
         # This documents expected behavior for config factories
         default_isolated = True
@@ -167,7 +167,7 @@ class TestConfigDefaults:
 
         assert config["isolated"] is True
 
-    def test_share_torch_defaults_false(self):
+    def test_share_torch_defaults_false(self) -> None:
         """share_torch defaults to False for safety."""
         default_share_torch = False
 
@@ -183,7 +183,7 @@ class TestConfigDefaults:
 
         assert config["share_torch"] is False
 
-    def test_dependencies_defaults_empty(self):
+    def test_dependencies_defaults_empty(self) -> None:
         """dependencies defaults to empty list."""
         config: ExtensionConfig = {
             "name": "ext",
@@ -197,7 +197,7 @@ class TestConfigDefaults:
 
         assert config["dependencies"] == []
 
-    def test_apis_defaults_empty(self):
+    def test_apis_defaults_empty(self) -> None:
         """apis defaults to empty list."""
         config: ExtensionConfig = {
             "name": "ext",

--- a/tests/test_cuda_wheels.py
+++ b/tests/test_cuda_wheels.py
@@ -525,7 +525,7 @@ def test_resolve_iterates_multiple_indexes(monkeypatch: Any) -> None:
     assert "pozzettiandrea" in url
 
 
-# ── Live network tests ────────────────────────────────────────────────
+# ── Live network tests (real network/venv work; expected slow: ~30s each) ───
 
 
 @pytest.mark.network
@@ -785,3 +785,87 @@ def test_share_torch_named_packages_can_install_with_no_deps(tmp_path: Any, monk
     assert "timm" in popen_calls[1]
     assert "--no-deps" in popen_calls[2]
     assert any("cc_torch-0.2-py3-none-any.whl" in token for token in popen_calls[2])
+
+
+def test_share_torch_no_deps_applies_without_cuda_wheels(tmp_path: Any, monkeypatch: Any) -> None:
+    """Named share_torch packages still split into a no-deps install without CUDA wheels."""
+    from pyisolate._internal.environment import install_dependencies
+
+    venv_path = tmp_path / "venvs" / "test-ext"
+    _fake_venv_python(venv_path)
+
+    config = {
+        "name": "test-ext",
+        "module_path": str(tmp_path),
+        "isolated": True,
+        "dependencies": ["timm", "pyyaml"],
+        "apis": [],
+        "share_torch": True,
+        "share_torch_no_deps": ["timm"],
+        "share_cuda_ipc": False,
+        "sandbox_mode": SandboxMode.DISABLED,
+        "sandbox": {},
+    }
+
+    popen_calls: list[list[str]] = []
+
+    class FakeProc:
+        def __init__(self, cmd: Any, **kwargs: Any) -> None:
+            popen_calls.append(cmd)
+            self.stdout: Any = iter([])
+            self.returncode = 0
+
+        def __enter__(self) -> Any:
+            return self
+
+        def __exit__(self, *args: Any) -> Any:
+            return False
+
+        def wait(self) -> Any:
+            return 0
+
+    monkeypatch.setattr("subprocess.Popen", FakeProc)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(
+        "pyisolate._internal.environment.exclude_satisfied_requirements",
+        lambda config, reqs, python_exe: reqs,
+    )
+
+    install_dependencies(venv_path, cast(ExtensionConfig, config), "test-ext")
+
+    assert len(popen_calls) == 2
+    assert "--no-deps" not in popen_calls[0]
+    assert "pyyaml" in popen_calls[0]
+    assert "timm" not in popen_calls[0]
+    assert "--no-deps" in popen_calls[1]
+    assert "timm" in popen_calls[1]
+
+
+def test_share_torch_no_deps_rejects_invalid_type(tmp_path: Any, monkeypatch: Any) -> None:
+    """Invalid share_torch_no_deps config should fail fast."""
+    from pyisolate._internal.environment import install_dependencies
+
+    venv_path = tmp_path / "venvs" / "test-ext"
+    _fake_venv_python(venv_path)
+
+    config = {
+        "name": "test-ext",
+        "module_path": str(tmp_path),
+        "isolated": True,
+        "dependencies": ["timm"],
+        "apis": [],
+        "share_torch": True,
+        "share_torch_no_deps": "timm",
+        "share_cuda_ipc": False,
+        "sandbox_mode": SandboxMode.DISABLED,
+        "sandbox": {},
+    }
+
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(
+        "pyisolate._internal.environment.exclude_satisfied_requirements",
+        lambda config, reqs, python_exe: reqs,
+    )
+
+    with pytest.raises(TypeError, match="share_torch_no_deps"):
+        install_dependencies(venv_path, cast(ExtensionConfig, config), "test-ext")

--- a/tests/test_cuda_wheels.py
+++ b/tests/test_cuda_wheels.py
@@ -7,22 +7,27 @@ perform a real wheel download or a real install.
 import builtins
 import io
 import sys
+from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 from packaging.tags import sys_tags
 
 from pyisolate._internal import environment
 from pyisolate._internal.cuda_wheels import (
+    CUDAWheelConfig,
     CUDAWheelResolutionError,
+    CUDAWheelRuntime,
     _normalize_cuda_wheel_config,
     get_cuda_wheel_runtime,
     resolve_cuda_wheel_requirements,
     resolve_cuda_wheel_url,
 )
+from pyisolate.config import ExtensionConfig, SandboxMode
 
 
-def _runtime() -> dict[str, object]:
+def _runtime() -> CUDAWheelRuntime:
     return {
         "torch": "2.8",
         "torch_nodot": "28",
@@ -42,7 +47,18 @@ def _simple_index_html(*filenames: str) -> str:
     return "<html><body>" + "".join(links) + "</body></html>"
 
 
-def test_resolve_cuda_wheel_requirement_to_direct_url(monkeypatch):
+def _fake_venv_python(venv_path: Path) -> Path:
+    if sys.platform == "win32":
+        python_path = venv_path / "Scripts" / "python.exe"
+    else:
+        python_path = venv_path / "bin" / "python"
+    python_path.parent.mkdir(parents=True, exist_ok=True)
+    python_path.write_text("#!/bin/sh\n")
+    python_path.chmod(0o755)
+    return python_path
+
+
+def test_resolve_cuda_wheel_requirement_to_direct_url(monkeypatch: Any) -> None:
     runtime = _runtime()
     wheel = _wheel_filename("flash_attn", "1.1.0+cu128torch28")
     page_url = "https://example.invalid/cuda-wheels/flash-attn/"
@@ -65,7 +81,7 @@ def test_resolve_cuda_wheel_requirement_to_direct_url(monkeypatch):
     assert resolved == [page_url + wheel]
 
 
-def test_resolve_cuda_wheel_requirement_supports_underscore_index(monkeypatch):
+def test_resolve_cuda_wheel_requirement_supports_underscore_index(monkeypatch: Any) -> None:
     runtime = _runtime()
     wheel = _wheel_filename("torch_generic_nms", "0.2.0+cu128torch28")
     page_url = "https://example.invalid/cuda-wheels/torch_generic_nms/"
@@ -88,7 +104,7 @@ def test_resolve_cuda_wheel_requirement_supports_underscore_index(monkeypatch):
     assert resolved == [page_url + wheel]
 
 
-def test_resolve_cuda_wheel_requirement_supports_percent_encoded_links(monkeypatch):
+def test_resolve_cuda_wheel_requirement_supports_percent_encoded_links(monkeypatch: Any) -> None:
     runtime = _runtime()
     wheel = _wheel_filename("torch_generic_nms", "0.1+cu128torch28")
     encoded_wheel = wheel.replace("+", "%2B")
@@ -112,7 +128,7 @@ def test_resolve_cuda_wheel_requirement_supports_percent_encoded_links(monkeypat
     assert resolved == [page_url + wheel]
 
 
-def test_resolve_cuda_wheel_requirement_honors_package_map(monkeypatch):
+def test_resolve_cuda_wheel_requirement_honors_package_map(monkeypatch: Any) -> None:
     runtime = _runtime()
     wheel = _wheel_filename("flash_attn", "1.2.0+cu128torch28")
     page_url = "https://example.invalid/cuda-wheels/flash_attn_special/"
@@ -135,7 +151,7 @@ def test_resolve_cuda_wheel_requirement_honors_package_map(monkeypatch):
     assert resolved == [page_url + wheel]
 
 
-def test_resolve_cuda_wheel_requirement_picks_highest_matching_version(monkeypatch):
+def test_resolve_cuda_wheel_requirement_picks_highest_matching_version(monkeypatch: Any) -> None:
     runtime = _runtime()
     compatible_old = _wheel_filename("flash_attn", "1.1.0+cu128torch28")
     compatible_new = _wheel_filename("flash_attn", "1.3.0+pt28cu128")
@@ -170,7 +186,7 @@ def test_resolve_cuda_wheel_requirement_picks_highest_matching_version(monkeypat
     assert resolved == [page_url + compatible_new]
 
 
-def test_resolve_cuda_wheel_requirement_prefers_better_supported_tag(monkeypatch):
+def test_resolve_cuda_wheel_requirement_prefers_better_supported_tag(monkeypatch: Any) -> None:
     all_tags = list(sys_tags())
     manylinux_tags = [t for t in all_tags if "manylinux" in t.platform and "x86_64" in t.platform]
     linux_tags = [t for t in all_tags if t.platform == "linux_x86_64"]
@@ -208,7 +224,7 @@ def test_resolve_cuda_wheel_requirement_prefers_better_supported_tag(monkeypatch
     assert resolved == [hyphen_page + preferred]
 
 
-def test_resolve_cuda_wheel_requirement_raises_when_no_match(monkeypatch):
+def test_resolve_cuda_wheel_requirement_raises_when_no_match(monkeypatch: Any) -> None:
     runtime = _runtime()
     wheel = _wheel_filename("flash_attn", "1.1.0+cu127torch28")
     page_url = "https://example.invalid/cuda-wheels/flash-attn/"
@@ -230,10 +246,10 @@ def test_resolve_cuda_wheel_requirement_raises_when_no_match(monkeypatch):
         )
 
 
-def test_get_cuda_wheel_runtime_raises_without_torch(monkeypatch):
+def test_get_cuda_wheel_runtime_raises_without_torch(monkeypatch: Any) -> Any:
     real_import = builtins.__import__
 
-    def missing_torch(name, *args, **kwargs):
+    def missing_torch(name: Any, *args: Any, **kwargs: Any) -> Any:
         if name == "torch":
             raise ImportError("missing torch")
         return real_import(name, *args, **kwargs)
@@ -244,7 +260,7 @@ def test_get_cuda_wheel_runtime_raises_without_torch(monkeypatch):
         get_cuda_wheel_runtime()
 
 
-def test_get_cuda_wheel_runtime_raises_without_cuda(monkeypatch):
+def test_get_cuda_wheel_runtime_raises_without_cuda(monkeypatch: Any) -> None:
     fake_torch = SimpleNamespace(
         __version__="2.8.1",
         version=SimpleNamespace(cuda=None),
@@ -255,7 +271,7 @@ def test_get_cuda_wheel_runtime_raises_without_cuda(monkeypatch):
         get_cuda_wheel_runtime()
 
 
-def test_install_dependencies_cache_invalidation_tracks_cuda_runtime(monkeypatch, tmp_path):
+def test_install_dependencies_cache_invalidation_tracks_cuda_runtime(monkeypatch: Any, tmp_path: Any) -> Any:
     import os
 
     venv_path = tmp_path / "venv"
@@ -285,24 +301,28 @@ def test_install_dependencies_cache_invalidation_tracks_cuda_runtime(monkeypatch
     popen_calls: list[list[str]] = []
 
     class MockPopen:
-        def __init__(self, cmd, **kwargs):
+        def __init__(self, cmd: Any, **kwargs: Any) -> None:
             popen_calls.append(cmd)
             self.stdout = io.StringIO("installed\n")
 
-        def wait(self):
+        def wait(self) -> Any:
             return 0
 
-        def __enter__(self):
+        def __enter__(self) -> Any:
             return self
 
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
             return False
 
     monkeypatch.setattr(environment.subprocess, "Popen", MockPopen)
 
-    config = {
+    config: ExtensionConfig = {
+        "name": "demo",
+        "isolated": True,
         "dependencies": ["flash-attn>=1.0"],
+        "apis": [],
         "share_torch": True,
+        "share_cuda_ipc": False,
         "cuda_wheels": {
             "index_url": "https://example.invalid/cuda-wheels/",
             "packages": ["flash-attn"],
@@ -328,7 +348,7 @@ def _wheel_filename_for_cpython(distribution: str, version: str, cpython: str) -
     return f"{distribution}-{version}-{cpython}-{cpython}-{tag.platform}.whl"
 
 
-def test_resolve_cuda_wheel_url_accepts_target_python_parameter(monkeypatch):
+def test_resolve_cuda_wheel_url_accepts_target_python_parameter(monkeypatch: Any) -> None:
     """AC-1: resolve_cuda_wheel_url accepts target_python=(3, 12) without TypeError."""
     runtime = _runtime()
     wheel_312 = _wheel_filename_for_cpython("flash_attn", "1.0.0+cu128torch28", "cp312")
@@ -356,7 +376,7 @@ def test_resolve_cuda_wheel_url_accepts_target_python_parameter(monkeypatch):
     assert "cp312" in url
 
 
-def test_resolve_cuda_wheel_uses_target_python_tags(monkeypatch):
+def test_resolve_cuda_wheel_uses_target_python_tags(monkeypatch: Any) -> None:
     """AC-2: target_python=(3, 12) selects cp312 wheel, not cp313."""
     runtime = _runtime()
     wheel_312 = _wheel_filename_for_cpython("flash_attn", "1.0.0+cu128torch28", "cp312")
@@ -385,7 +405,7 @@ def test_resolve_cuda_wheel_uses_target_python_tags(monkeypatch):
     assert "cp313" not in url
 
 
-def test_resolve_cuda_wheel_requirements_threads_target_python(monkeypatch):
+def test_resolve_cuda_wheel_requirements_threads_target_python(monkeypatch: Any) -> None:
     """AC-3: resolve_cuda_wheel_requirements threads target_python to resolve_cuda_wheel_url."""
     runtime = _runtime()
     wheel_312 = _wheel_filename_for_cpython("flash_attn", "1.0.0+cu128torch28", "cp312")
@@ -412,7 +432,7 @@ def test_resolve_cuda_wheel_requirements_threads_target_python(monkeypatch):
     assert "cp313" not in resolved[0]
 
 
-def test_resolve_cuda_wheel_target_python_rejects_host_only_wheel(monkeypatch):
+def test_resolve_cuda_wheel_target_python_rejects_host_only_wheel(monkeypatch: Any) -> None:
     """AC-4: target_python=(3, 12) raises when only cp313 wheel available."""
     runtime = _runtime()
     wheel_313_only = _wheel_filename_for_cpython("flash_attn", "1.0.0+cu128torch28", "cp313")
@@ -442,9 +462,9 @@ def test_resolve_cuda_wheel_target_python_rejects_host_only_wheel(monkeypatch):
 # ── index_urls (plural) support tests ─────────────────────────────────
 
 
-def test_normalize_config_index_urls():
+def test_normalize_config_index_urls() -> None:
     """AC-1: _normalize_cuda_wheel_config accepts index_urls (plural list)."""
-    config = {
+    config: CUDAWheelConfig = {
         "index_urls": [
             "https://download.pytorch.org/whl/cu128",
             "https://pozzettiandrea.github.io/cuda-wheels/",
@@ -460,9 +480,9 @@ def test_normalize_config_index_urls():
     assert result["index_urls"][1] == "https://pozzettiandrea.github.io/cuda-wheels/"
 
 
-def test_normalize_config_singular_returns_index_urls_key():
+def test_normalize_config_singular_returns_index_urls_key() -> None:
     """AC-2: _normalize_cuda_wheel_config with index_url (singular) returns index_urls key (plural)."""
-    config = {
+    config: CUDAWheelConfig = {
         "index_url": "https://example.invalid/cuda-wheels",
         "packages": ["flash-attn"],
         "package_map": {},
@@ -473,7 +493,7 @@ def test_normalize_config_singular_returns_index_urls_key():
     assert result["index_urls"] == ["https://example.invalid/cuda-wheels/"]
 
 
-def test_resolve_iterates_multiple_indexes(monkeypatch):
+def test_resolve_iterates_multiple_indexes(monkeypatch: Any) -> None:
     """AC-3: resolve_cuda_wheel_url iterates multiple index URLs to find a package."""
     runtime = _runtime()
     wheel = _wheel_filename("cumesh", "0.0.1+cu128torch28")
@@ -509,7 +529,7 @@ def test_resolve_iterates_multiple_indexes(monkeypatch):
 
 
 @pytest.mark.network
-def test_resolve_sageattention_for_target_python_312():
+def test_resolve_sageattention_for_target_python_312() -> None:
     """AC-1/AC-2: Live index resolves cp312 wheel with correct torch+CUDA pattern."""
     from packaging.requirements import Requirement
 
@@ -536,7 +556,7 @@ def test_resolve_sageattention_for_target_python_312():
 
 
 @pytest.mark.network
-def test_resolve_sageattention_host_tags_selects_cp313():
+def test_resolve_sageattention_host_tags_selects_cp313() -> None:
     """AC-3: Without target_python selects host cpXXX; with target_python=(3, 11) selects cp311."""
     from packaging.requirements import Requirement
 
@@ -544,7 +564,7 @@ def test_resolve_sageattention_host_tags_selects_cp313():
 
     # Host tags (should select host interpreter's cp tag — cp312 on this venv)
     runtime_host = get_cuda_wheel_runtime()
-    config = {
+    config: CUDAWheelConfig = {
         "index_url": "https://pozzettiandrea.github.io/cuda-wheels/",
         "packages": ["sageattention"],
         "package_map": {},
@@ -565,3 +585,203 @@ def test_resolve_sageattention_host_tags_selects_cp313():
     assert host_cp not in url_target or host_cp == "cp311", (
         f"Unexpected {host_cp} in target URL: {url_target}"
     )
+
+
+def test_extra_index_urls_plumbed_to_install_command(tmp_path: Any, monkeypatch: Any) -> Any:
+    """extra_index_urls in ExtensionConfig become --extra-index-url args in uv pip install."""
+    from pyisolate._internal.environment import install_dependencies
+
+    venv_path = tmp_path / "venvs" / "test-ext"
+
+    config: ExtensionConfig = {
+        "name": "test-ext",
+        "module_path": str(tmp_path),
+        "isolated": True,
+        "dependencies": ["numpy>=1.0"],
+        "apis": [],
+        "share_torch": True,
+        "share_cuda_ipc": False,
+        "sandbox_mode": SandboxMode.DISABLED,
+        "sandbox": {},
+        "extra_index_urls": ["https://example.invalid/simple"],
+    }
+
+    captured_cmd: list[str] = []
+
+    class FakeProc:
+        def __init__(self, cmd: Any, **kwargs: Any) -> None:
+            captured_cmd.extend(cmd)
+            self.stdout: Any = iter([])
+            self.returncode = 0
+
+        def __enter__(self) -> Any:
+            return self
+
+        def __exit__(self, *args: Any) -> None:
+            pass
+
+        def wait(self) -> Any:
+            return 0
+
+    monkeypatch.setattr("subprocess.Popen", FakeProc)
+    monkeypatch.setattr("subprocess.check_call", lambda cmd, **kw: None)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(
+        "pyisolate._internal.environment.exclude_satisfied_requirements",
+        lambda config, reqs, python_exe: reqs,
+    )
+
+    # Set up fake venv structure (skip create_venv — we only test install_dependencies)
+    _fake_venv_python(venv_path)
+
+    install_dependencies(venv_path, cast(ExtensionConfig, config), "test-ext")
+
+    assert "--extra-index-url" in captured_cmd
+    idx = captured_cmd.index("--extra-index-url")
+    assert captured_cmd[idx + 1] == "https://example.invalid/simple"
+
+
+def test_share_torch_cuda_wheels_install_uses_no_deps_for_resolved_urls(
+    tmp_path: Any, monkeypatch: Any
+) -> Any:
+    """Resolved CUDA wheel URLs must install in a separate --no-deps step under share_torch."""
+    from pyisolate._internal.environment import install_dependencies
+
+    venv_path = tmp_path / "venvs" / "test-ext"
+    _fake_venv_python(venv_path)
+
+    config = {
+        "name": "test-ext",
+        "module_path": str(tmp_path),
+        "isolated": True,
+        "dependencies": ["cc-torch", "torch-generic-nms", "timm"],
+        "apis": [],
+        "share_torch": True,
+        "share_cuda_ipc": False,
+        "sandbox_mode": SandboxMode.DISABLED,
+        "sandbox": {},
+        "cuda_wheels": {
+            "index_url": "https://example.invalid/cuda-wheels/",
+            "packages": ["cc-torch", "torch-generic-nms"],
+            "package_map": {},
+        },
+    }
+
+    popen_calls: list[list[str]] = []
+
+    class FakeProc:
+        def __init__(self, cmd: Any, **kwargs: Any) -> None:
+            popen_calls.append(cmd)
+            self.stdout: Any = iter([])
+            self.returncode = 0
+
+        def __enter__(self) -> Any:
+            return self
+
+        def __exit__(self, *args: Any) -> Any:
+            return False
+
+        def wait(self) -> Any:
+            return 0
+
+    monkeypatch.setattr("subprocess.Popen", FakeProc)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(
+        "pyisolate._internal.environment.exclude_satisfied_requirements",
+        lambda config, reqs, python_exe: reqs,
+    )
+    monkeypatch.setattr(
+        "pyisolate._internal.environment.get_cuda_wheel_runtime_descriptor",
+        lambda: {"torch": "2.11", "cuda": "13.0", "python_tags": ["cp313"]},
+    )
+    monkeypatch.setattr(
+        "pyisolate._internal.environment.resolve_cuda_wheel_requirements",
+        lambda requirements, config: [
+            "https://github.com/example/cuda-wheels/releases/download/cc_torch-latest/cc_torch-0.2-py3-none-any.whl",
+            "https://github.com/example/cuda-wheels/releases/download/torch_generic_nms-latest/torch_generic_nms-0.1-py3-none-any.whl",
+            "timm",
+        ],
+    )
+
+    install_dependencies(venv_path, cast(ExtensionConfig, config), "test-ext")
+
+    assert len(popen_calls) == 2
+    assert "--no-deps" not in popen_calls[0]
+    assert "timm" in popen_calls[0]
+    assert "--no-deps" in popen_calls[1]
+    assert any("cc_torch-0.2-py3-none-any.whl" in token for token in popen_calls[1])
+    assert any("torch_generic_nms-0.1-py3-none-any.whl" in token for token in popen_calls[1])
+
+
+def test_share_torch_named_packages_can_install_with_no_deps(tmp_path: Any, monkeypatch: Any) -> Any:
+    """Named share_torch packages should install via a separate --no-deps step."""
+    from pyisolate._internal.environment import install_dependencies
+
+    venv_path = tmp_path / "venvs" / "test-ext"
+    _fake_venv_python(venv_path)
+
+    config = {
+        "name": "test-ext",
+        "module_path": str(tmp_path),
+        "isolated": True,
+        "dependencies": ["cc-torch", "torch-generic-nms", "timm", "pyyaml"],
+        "apis": [],
+        "share_torch": True,
+        "share_torch_no_deps": ["timm"],
+        "share_cuda_ipc": False,
+        "sandbox_mode": SandboxMode.DISABLED,
+        "sandbox": {},
+        "cuda_wheels": {
+            "index_url": "https://example.invalid/cuda-wheels/",
+            "packages": ["cc-torch", "torch-generic-nms"],
+            "package_map": {},
+        },
+    }
+
+    popen_calls: list[list[str]] = []
+
+    class FakeProc:
+        def __init__(self, cmd: Any, **kwargs: Any) -> None:
+            popen_calls.append(cmd)
+            self.stdout: Any = iter([])
+            self.returncode = 0
+
+        def __enter__(self) -> Any:
+            return self
+
+        def __exit__(self, *args: Any) -> Any:
+            return False
+
+        def wait(self) -> Any:
+            return 0
+
+    monkeypatch.setattr("subprocess.Popen", FakeProc)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(
+        "pyisolate._internal.environment.exclude_satisfied_requirements",
+        lambda config, reqs, python_exe: reqs,
+    )
+    monkeypatch.setattr(
+        "pyisolate._internal.environment.get_cuda_wheel_runtime_descriptor",
+        lambda: {"torch": "2.11", "cuda": "13.0", "python_tags": ["cp313"]},
+    )
+    monkeypatch.setattr(
+        "pyisolate._internal.environment.resolve_cuda_wheel_requirements",
+        lambda requirements, config: [
+            "https://github.com/example/cuda-wheels/releases/download/cc_torch-latest/cc_torch-0.2-py3-none-any.whl",
+            "https://github.com/example/cuda-wheels/releases/download/torch_generic_nms-latest/torch_generic_nms-0.1-py3-none-any.whl",
+            "timm",
+            "pyyaml",
+        ],
+    )
+
+    install_dependencies(venv_path, cast(ExtensionConfig, config), "test-ext")
+
+    assert len(popen_calls) == 3
+    assert "--no-deps" not in popen_calls[0]
+    assert "pyyaml" in popen_calls[0]
+    assert "timm" not in popen_calls[0]
+    assert "--no-deps" in popen_calls[1]
+    assert "timm" in popen_calls[1]
+    assert "--no-deps" in popen_calls[2]
+    assert any("cc_torch-0.2-py3-none-any.whl" in token for token in popen_calls[2])

--- a/tests/test_environment_conda.py
+++ b/tests/test_environment_conda.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -21,20 +22,24 @@ from pyisolate._internal.environment_conda import (
     _toml_path_string,
     create_conda_env,
 )
+from pyisolate.config import ExtensionConfig
 
 
-def _make_conda_config(**overrides: object) -> dict:
+def _make_conda_config(**overrides: object) -> ExtensionConfig:
     """Minimal valid conda config for tests."""
-    base: dict = {
+    base: ExtensionConfig = {
         "package_manager": "conda",
         "conda_channels": ["conda-forge"],
         "conda_dependencies": ["numpy"],
         "dependencies": ["requests"],
         "share_torch": False,
         "module": "test_ext",
+        "name": "test_ext",
+        "isolated": True,
+        "apis": [],
+        "share_cuda_ipc": False,
     }
-    base.update(overrides)
-    return base
+    return cast(ExtensionConfig, {**base, **overrides})
 
 
 def _pixi_python_path(env_path: Path) -> Path:
@@ -159,6 +164,46 @@ class TestGeneratePixiToml:
         toml_str = _generate_pixi_toml(config)
         assert 'version = ">=0.4.30"' in toml_str
 
+    def test_generate_pixi_toml_uses_version_pin_when_no_pyproject(self, tmp_path: Path) -> None:
+        config = _make_conda_config()
+        with patch(
+            "pyisolate._internal.environment_conda._pyisolate_source_path",
+            return_value=tmp_path,
+        ):
+            toml_str = _generate_pixi_toml(config)
+        assert 'pyisolate = "==' in toml_str
+        assert "pyisolate = { path =" not in toml_str
+
+    def test_generate_pixi_toml_uses_path_when_pyproject_exists(self, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'pyisolate'\n")
+        config = _make_conda_config()
+        with patch(
+            "pyisolate._internal.environment_conda._pyisolate_source_path",
+            return_value=tmp_path,
+        ):
+            toml_str = _generate_pixi_toml(config)
+        assert "pyisolate = { path =" in toml_str
+        assert 'pyisolate = "==' not in toml_str
+
+    def test_generate_pixi_toml_pypi_fallback_produces_parseable_toml(self, tmp_path: Path) -> None:
+        try:
+            import tomllib  # type: ignore[import-not-found]
+        except ModuleNotFoundError:
+            import tomli as tomllib  # type: ignore[import-not-found]
+
+        config = _make_conda_config(dependencies=["jax[cuda12]>=0.4.30", "numpy>=2.2"])
+        with patch(
+            "pyisolate._internal.environment_conda._pyisolate_source_path",
+            return_value=tmp_path,
+        ):
+            toml_str = _generate_pixi_toml(config)
+        parsed = tomllib.loads(toml_str)
+        pyisolate_dep = parsed["pypi-dependencies"]["pyisolate"]
+        assert isinstance(pyisolate_dep, str), f"Expected string, got {type(pyisolate_dep)}: {pyisolate_dep}"
+        assert pyisolate_dep.startswith("=="), (
+            f"Expected version pin starting with '==', got: {pyisolate_dep}"
+        )
+
 
 # ── _parse_dep ──────────────────────────────────────────────────────
 
@@ -237,7 +282,13 @@ class TestParseDep:
 class TestCreateCondaEnv:
     def test_pixi_not_found_raises(self, tmp_path: Path) -> None:
         config = _make_conda_config()
-        with patch("shutil.which", return_value=None), pytest.raises(RuntimeError, match="pixi.*not found"):
+        with (
+            patch(
+                "pyisolate._internal.pixi_provisioner.ensure_pixi",
+                side_effect=RuntimeError("pixi not found"),
+            ),
+            pytest.raises(RuntimeError, match="pixi not found"),
+        ):
             create_conda_env(tmp_path / "env", config, "test_ext")
 
     def test_pixi_install_called(self, tmp_path: Path) -> None:
@@ -246,7 +297,7 @@ class TestCreateCondaEnv:
         pixi_python = _pixi_python_path(env_path)
 
         with (
-            patch("shutil.which", return_value="/usr/bin/pixi"),
+            patch("pyisolate._internal.pixi_provisioner.ensure_pixi", return_value="/usr/bin/pixi"),
             patch("subprocess.check_call") as mock_call,
             patch.object(Path, "exists", return_value=True),
         ):
@@ -266,7 +317,7 @@ class TestCreateCondaEnv:
 
         config = _make_conda_config()
         with (
-            patch("shutil.which", return_value="/usr/bin/pixi"),
+            patch("pyisolate._internal.pixi_provisioner.ensure_pixi", return_value="/usr/bin/pixi"),
             patch(
                 "subprocess.check_call",
                 side_effect=subprocess.CalledProcessError(1, "pixi"),
@@ -287,7 +338,7 @@ class TestCreateCondaEnv:
         pixi_python = _pixi_python_path(env_path)
 
         with (
-            patch("shutil.which", return_value="/usr/bin/pixi"),
+            patch("pyisolate._internal.pixi_provisioner.ensure_pixi", return_value="/usr/bin/pixi"),
             patch("subprocess.check_call") as mock_check_call,
             patch(
                 "pyisolate._internal.environment_conda._install_cuda_wheels_into_pixi"
@@ -311,7 +362,7 @@ class TestCreateCondaEnv:
         pixi_python = _pixi_python_path(env_path)
 
         with (
-            patch("shutil.which", return_value="/usr/bin/pixi"),
+            patch("pyisolate._internal.pixi_provisioner.ensure_pixi", return_value="/usr/bin/pixi"),
             patch("subprocess.check_call"),
         ):
             pixi_python.parent.mkdir(parents=True, exist_ok=True)
@@ -332,7 +383,7 @@ class TestCreateCondaEnv:
         monkeypatch.setenv("TMPDIR", str(stale_tmpdir))
 
         with (
-            patch("shutil.which", return_value="/usr/bin/pixi"),
+            patch("pyisolate._internal.pixi_provisioner.ensure_pixi", return_value="/usr/bin/pixi"),
             patch("subprocess.check_call") as mock_call,
             patch(
                 "pyisolate._internal.environment_conda._resolve_pixi_python",
@@ -374,7 +425,7 @@ class TestCreateCondaEnv:
         pixi_python.touch()
 
         with (
-            patch("shutil.which", return_value="/usr/bin/pixi"),
+            patch("pyisolate._internal.pixi_provisioner.ensure_pixi", return_value="/usr/bin/pixi"),
             patch("subprocess.check_call") as mock_call,
         ):
             create_conda_env(env_path, config, "test_ext")
@@ -414,11 +465,11 @@ class TestResolvePixiPython:
 # ── _install_cuda_wheels_into_pixi target_python threading ─────────────
 
 
-def test_install_cuda_wheels_passes_target_python(monkeypatch, tmp_path):
+def test_install_cuda_wheels_passes_target_python(monkeypatch: Any, tmp_path: Any) -> Any:
     """AC-1: conda_python='3.12.*' is parsed and passed as target_python=(3, 12)."""
     captured_kwargs: list[dict] = []
 
-    def mock_resolve(deps, config, **kwargs):
+    def mock_resolve(deps: Any, config: Any, **kwargs: Any) -> Any:
         captured_kwargs.append(kwargs)
         return deps  # return unchanged (no wheel resolution)
 
@@ -446,11 +497,11 @@ def test_install_cuda_wheels_passes_target_python(monkeypatch, tmp_path):
     assert captured_kwargs[0]["target_python"] == (3, 12)
 
 
-def test_install_cuda_wheels_wildcard_python_uses_host_tags(monkeypatch, tmp_path):
+def test_install_cuda_wheels_wildcard_python_uses_host_tags(monkeypatch: Any, tmp_path: Any) -> Any:
     """AC-2: conda_python='*' passes target_python=None (host tags fallback)."""
     captured_kwargs: list[dict] = []
 
-    def mock_resolve(deps, config, **kwargs):
+    def mock_resolve(deps: Any, config: Any, **kwargs: Any) -> Any:
         captured_kwargs.append(kwargs)
         return deps
 
@@ -478,11 +529,11 @@ def test_install_cuda_wheels_wildcard_python_uses_host_tags(monkeypatch, tmp_pat
     assert captured_kwargs[0]["target_python"] is None
 
 
-def test_install_cuda_wheels_parses_311(monkeypatch, tmp_path):
+def test_install_cuda_wheels_parses_311(monkeypatch: Any, tmp_path: Any) -> Any:
     """AC-3: conda_python='3.11.*' parses to target_python=(3, 11)."""
     captured_kwargs: list[dict] = []
 
-    def mock_resolve(deps, config, **kwargs):
+    def mock_resolve(deps: Any, config: Any, **kwargs: Any) -> Any:
         captured_kwargs.append(kwargs)
         return deps
 
@@ -514,7 +565,7 @@ def test_install_cuda_wheels_parses_311(monkeypatch, tmp_path):
 
 
 class TestResolveUvExe:
-    def test_install_cuda_wheels_uv_exe_fallback(self, monkeypatch, tmp_path):
+    def test_install_cuda_wheels_uv_exe_fallback(self, monkeypatch: Any, tmp_path: Any) -> None:
         """When python_exe.parent/uv does not exist, falls back to shutil.which."""
         # Create python_exe in a dir without uv
         python_exe = tmp_path / "no_uv_here" / "python"
@@ -528,7 +579,7 @@ class TestResolveUvExe:
         system_uv = shutil.which("uv")
         assert resolved == system_uv
 
-    def test_install_local_wheels_uv_exe_fallback(self, monkeypatch, tmp_path):
+    def test_install_local_wheels_uv_exe_fallback(self, monkeypatch: Any, tmp_path: Any) -> None:
         """_install_local_wheels uses _resolve_uv_exe and falls back correctly."""
         python_exe = tmp_path / "no_uv_here" / "python"
         python_exe.parent.mkdir(parents=True)
@@ -541,7 +592,7 @@ class TestResolveUvExe:
 
         captured_cmds: list[list[str]] = []
 
-        def mock_check_call(cmd, **kwargs):
+        def mock_check_call(cmd: Any, **kwargs: Any) -> None:
             captured_cmds.append(cmd)
 
         monkeypatch.setattr("subprocess.check_call", mock_check_call)
@@ -555,7 +606,7 @@ class TestResolveUvExe:
         system_uv = shutil.which("uv")
         assert captured_cmds[0][0] == system_uv
 
-    def test_install_cuda_wheels_uv_exe_prefers_local(self, tmp_path):
+    def test_install_cuda_wheels_uv_exe_prefers_local(self, tmp_path: Any) -> None:
         """When python_exe.parent/uv exists, it is preferred over shutil.which."""
         python_exe = tmp_path / "bin" / "python"
         python_exe.parent.mkdir(parents=True)
@@ -566,7 +617,7 @@ class TestResolveUvExe:
         resolved = _resolve_uv_exe(python_exe)
         assert resolved == str(local_uv)
 
-    def test_install_cuda_wheels_uv_exe_windows_layout(self, tmp_path):
+    def test_install_cuda_wheels_uv_exe_windows_layout(self, tmp_path: Any) -> None:
         """Windows pixi layout: python at envs/default/python.exe, no bin/ dir."""
         # Simulate Windows pixi path structure
         pixi_default = tmp_path / ".pixi" / "envs" / "default"

--- a/tests/test_environment_sealed_worker.py
+++ b/tests/test_environment_sealed_worker.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import io
 import os
 from pathlib import Path
+from typing import Any
 
 from pyisolate._internal import environment
+from pyisolate.config import ExtensionConfig
 
 
 def _mock_venv_python(venv_path: Path) -> None:
@@ -13,21 +15,21 @@ def _mock_venv_python(venv_path: Path) -> None:
     python_exe.write_text("#!/usr/bin/env python\n", encoding="utf-8")
 
 
-def _capture_install_commands(monkeypatch) -> list[list[str]]:
+def _capture_install_commands(monkeypatch: Any) -> list[list[str]]:
     popen_calls: list[list[str]] = []
 
     class MockPopen:
-        def __init__(self, cmd, **kwargs):
+        def __init__(self, cmd: Any, **kwargs: Any) -> None:
             popen_calls.append(cmd)
             self.stdout = io.StringIO("installed\n")
 
-        def wait(self):
+        def wait(self) -> Any:
             return 0
 
-        def __enter__(self):
+        def __enter__(self) -> Any:
             return self
 
-        def __exit__(self, exc_type, exc, tb):
+        def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
             return False
 
     monkeypatch.setattr(environment.shutil, "which", lambda binary: "/usr/bin/uv")
@@ -35,14 +37,18 @@ def _capture_install_commands(monkeypatch) -> list[list[str]]:
     return popen_calls
 
 
-def test_sealed_worker_uv_does_not_auto_inject_torch(monkeypatch, tmp_path: Path) -> None:
+def test_sealed_worker_uv_does_not_auto_inject_torch(monkeypatch: Any, tmp_path: Path) -> None:
     venv_path = tmp_path / "venv"
     _mock_venv_python(venv_path)
     popen_calls = _capture_install_commands(monkeypatch)
 
-    config = {
+    config: ExtensionConfig = {
+        "name": "demo",
+        "isolated": True,
         "dependencies": ["boltons"],
+        "apis": [],
         "share_torch": False,
+        "share_cuda_ipc": False,
         "execution_model": "sealed_worker",
     }
 
@@ -54,14 +60,18 @@ def test_sealed_worker_uv_does_not_auto_inject_torch(monkeypatch, tmp_path: Path
     assert not any(str(part).startswith("torch==") for part in cmd)
 
 
-def test_host_coupled_uv_still_auto_injects_torch(monkeypatch, tmp_path: Path) -> None:
+def test_host_coupled_uv_still_auto_injects_torch(monkeypatch: Any, tmp_path: Path) -> None:
     venv_path = tmp_path / "venv"
     _mock_venv_python(venv_path)
     popen_calls = _capture_install_commands(monkeypatch)
 
-    config = {
+    config: ExtensionConfig = {
+        "name": "demo",
+        "isolated": True,
         "dependencies": ["boltons"],
+        "apis": [],
         "share_torch": False,
+        "share_cuda_ipc": False,
     }
 
     environment.install_dependencies(venv_path, config, "demo")

--- a/tests/test_event_channel.py
+++ b/tests/test_event_channel.py
@@ -8,6 +8,7 @@ Tests verify:
 """
 
 import asyncio
+from typing import Any, cast
 
 import pytest
 
@@ -17,12 +18,12 @@ from pyisolate._internal.event_bridge import _EventBridge
 class TestEventBridgeDispatch:
     """Tests for _EventBridge RPC callee behavior."""
 
-    def test_emit_event_dispatches_to_handler(self):
+    def test_emit_event_dispatches_to_handler(self) -> None:
         """emit_event("progress", payload) calls the registered handler with exact payload."""
         bridge = _EventBridge()
         received = []
 
-        def handler(payload):
+        def handler(payload: Any) -> None:
             received.append(payload)
 
         bridge.register_handler("progress", handler)
@@ -31,14 +32,14 @@ class TestEventBridgeDispatch:
         assert len(received) == 1
         assert received[0] == {"value": 5, "total": 10}
 
-    def test_emit_unregistered_event_raises(self):
+    def test_emit_unregistered_event_raises(self) -> None:
         """emit_event("unknown_event", {}) raises ValueError, not silently dropped."""
         bridge = _EventBridge()
 
         with pytest.raises(ValueError, match="No handler registered for event 'unknown_event'"):
             asyncio.get_event_loop().run_until_complete(bridge.dispatch("unknown_event", {}))
 
-    def test_emit_event_rejects_non_json_payload(self):
+    def test_emit_event_rejects_non_json_payload(self) -> None:
         """emit_event with non-JSON-serializable payload raises immediately."""
         from pyisolate.shared import ExtensionLocal
 
@@ -50,14 +51,14 @@ class TestEventBridgeDispatch:
             pass
 
         with pytest.raises(TypeError):
-            ext.emit_event("progress", NotSerializable())
+            ext.emit_event("progress", cast(Any, NotSerializable()))
 
-    def test_dispatch_with_async_handler(self):
+    def test_dispatch_with_async_handler(self) -> None:
         """Async handlers are awaited correctly."""
         bridge = _EventBridge()
         received = []
 
-        async def async_handler(payload):
+        async def async_handler(payload: Any) -> None:
             received.append(payload)
 
         bridge.register_handler("test", async_handler)
@@ -65,7 +66,7 @@ class TestEventBridgeDispatch:
 
         assert received == [{"key": "value"}]
 
-    def test_multiple_events_independent(self):
+    def test_multiple_events_independent(self) -> None:
         """Different event names dispatch to different handlers."""
         bridge = _EventBridge()
         progress_calls = []
@@ -84,14 +85,14 @@ class TestEventBridgeDispatch:
 class TestApiSurface:
     """Tests that the event channel API exists on the right classes."""
 
-    def test_extension_base_has_emit_event(self):
+    def test_extension_base_has_emit_event(self) -> None:
         """ExtensionBase has emit_event method."""
         from pyisolate.shared import ExtensionBase
 
         assert hasattr(ExtensionBase, "emit_event")
         assert callable(ExtensionBase.emit_event)
 
-    def test_sealed_node_extension_has_emit_event(self):
+    def test_sealed_node_extension_has_emit_event(self) -> None:
         """SealedNodeExtension inherits emit_event from ExtensionBase."""
         from pyisolate.sealed import SealedNodeExtension
 

--- a/tests/test_exact_proxy_bootstrap.py
+++ b/tests/test_exact_proxy_bootstrap.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from pyisolate._internal.host import Extension
+from pyisolate.config import ExtensionConfig
 from pyisolate.shared import ExtensionBase
 
 
@@ -14,7 +16,7 @@ class DummyProxy:
 DummyProxy.__module__ = "tests.test_exact_proxy_bootstrap"
 
 
-def _make_extension(config: dict) -> Extension:
+def _make_extension(config: ExtensionConfig) -> Extension:
     ext = Extension.__new__(Extension)
     ext.name = config["name"]
     ext.normalized_name = config["name"]
@@ -30,7 +32,7 @@ def _make_extension(config: dict) -> Extension:
     return ext
 
 
-def _capture_bootstrap_payload(config: dict) -> dict:
+def _capture_bootstrap_payload(config: ExtensionConfig) -> dict[str, Any]:
     ext = _make_extension(config)
 
     listener = MagicMock()
@@ -69,22 +71,25 @@ def _capture_bootstrap_payload(config: dict) -> dict:
         mock_socket.SOCK_STREAM = 1
         ext._launch_with_uds()
 
-    return transport.send.call_args[0][0]
+    return cast(dict[str, Any], transport.send.call_args[0][0])
 
 
 def test_sealed_worker_exact_proxy_binding() -> None:
     payload = _capture_bootstrap_payload(
-        {
-            "name": "test_ext",
-            "module": "test_module",
-            "module_path": "/fake/module",
-            "dependencies": [],
-            "share_torch": False,
-            "share_cuda_ipc": False,
-            "package_manager": "uv",
-            "execution_model": "sealed_worker",
-            "apis": [DummyProxy],
-        }
+        cast(
+            ExtensionConfig,
+            {
+                "name": "test_ext",
+                "module": "test_module",
+                "module_path": "/fake/module",
+                "dependencies": [],
+                "share_torch": False,
+                "share_cuda_ipc": False,
+                "package_manager": "uv",
+                "execution_model": "sealed_worker",
+                "apis": [DummyProxy],
+            },
+        )
     )
 
     assert payload["snapshot"]["apply_host_sys_path"] is False

--- a/tests/test_extension_lifecycle.py
+++ b/tests/test_extension_lifecycle.py
@@ -21,7 +21,7 @@ from pyisolate.config import ExtensionConfig
 class TestExtensionConfig:
     """Tests for ExtensionConfig TypedDict."""
 
-    def test_config_requires_name(self):
+    def test_config_requires_name(self) -> None:
         """ExtensionConfig must have a name."""
         config: ExtensionConfig = {
             "name": "test_ext",
@@ -34,7 +34,7 @@ class TestExtensionConfig:
         }
         assert config["name"] == "test_ext"
 
-    def test_config_requires_module_path(self):
+    def test_config_requires_module_path(self) -> None:
         """ExtensionConfig must have a module_path."""
         config: ExtensionConfig = {
             "name": "test_ext",
@@ -47,7 +47,7 @@ class TestExtensionConfig:
         }
         assert config["module_path"] == "/path/to/ext"
 
-    def test_config_with_dependencies(self):
+    def test_config_with_dependencies(self) -> None:
         """ExtensionConfig accepts dependencies list."""
         config: ExtensionConfig = {
             "name": "test_ext",
@@ -61,7 +61,7 @@ class TestExtensionConfig:
         assert "numpy>=1.20" in config["dependencies"]
         assert "pillow" in config["dependencies"]
 
-    def test_config_share_torch(self):
+    def test_config_share_torch(self) -> None:
         """ExtensionConfig accepts share_torch flag."""
         config: ExtensionConfig = {
             "name": "test_ext",
@@ -78,7 +78,7 @@ class TestExtensionConfig:
 class TestExtensionVenvPath:
     """Tests for extension venv path computation."""
 
-    def test_venv_path_includes_extension_name(self):
+    def test_venv_path_includes_extension_name(self) -> None:
         """Venv path should include extension name for isolation."""
         # This tests the contract, not implementation
         config: ExtensionConfig = {
@@ -98,7 +98,7 @@ class TestExtensionVenvPath:
 class TestExtensionManifest:
     """Tests for extension manifest (pyisolate.yaml) parsing."""
 
-    def test_manifest_from_yaml(self, tmp_path: Path):
+    def test_manifest_from_yaml(self, tmp_path: Path) -> None:
         """Extension can be configured via YAML manifest."""
         manifest_content = """
 isolated: true
@@ -111,7 +111,7 @@ dependencies:
         manifest_path.write_text(manifest_content)
 
         # Parse manifest
-        import yaml
+        import yaml  # type: ignore[import-untyped]
 
         with open(manifest_path) as f:
             manifest = yaml.safe_load(f)
@@ -120,7 +120,7 @@ dependencies:
         assert manifest["share_torch"] is True
         assert "numpy>=1.20" in manifest["dependencies"]
 
-    def test_manifest_defaults_isolated_true(self, tmp_path: Path):
+    def test_manifest_defaults_isolated_true(self, tmp_path: Path) -> None:
         """Missing 'isolated' defaults to True."""
         manifest_content = """
 dependencies: []
@@ -128,7 +128,7 @@ dependencies: []
         manifest_path = tmp_path / "pyisolate.yaml"
         manifest_path.write_text(manifest_content)
 
-        import yaml
+        import yaml  # type: ignore[import-untyped]
 
         with open(manifest_path) as f:
             manifest = yaml.safe_load(f)
@@ -154,7 +154,7 @@ class TestExtensionLifecycleContract:
     Extension class must fulfill.
     """
 
-    def test_extension_requires_config(self):
+    def test_extension_requires_config(self) -> None:
         """Extension must be created with a config."""
         config: ExtensionConfig = {
             "name": "test_ext",
@@ -168,7 +168,7 @@ class TestExtensionLifecycleContract:
         # Contract: Extension accepts config in constructor
         assert config["name"] == "test_ext"
 
-    def test_extension_lifecycle_phases(self):
+    def test_extension_lifecycle_phases(self) -> None:
         """Document the extension lifecycle phases."""
         # Phase 1: Configuration
         # - ExtensionConfig created from manifest or programmatically
@@ -195,7 +195,7 @@ class TestExtensionLifecycleContract:
         phases = ["config", "venv", "launch", "execute", "shutdown"]
         assert len(phases) == 5
 
-    def test_extension_stop_is_idempotent(self):
+    def test_extension_stop_is_idempotent(self) -> None:
         """Stopping an already-stopped extension should not error."""
         # Contract: calling stop() multiple times is safe
         # This is tested at contract level, not implementation
@@ -204,7 +204,7 @@ class TestExtensionLifecycleContract:
 class TestDependencyValidation:
     """Tests for dependency validation."""
 
-    def test_valid_dependency_format(self):
+    def test_valid_dependency_format(self) -> None:
         """Dependencies should be pip-installable strings."""
         valid_deps = [
             "numpy",
@@ -226,7 +226,7 @@ class TestDependencyValidation:
 
         assert config["dependencies"] == valid_deps
 
-    def test_empty_dependencies_allowed(self):
+    def test_empty_dependencies_allowed(self) -> None:
         """Extensions with no dependencies are valid."""
         config: ExtensionConfig = {
             "name": "test",

--- a/tests/test_extension_safety.py
+++ b/tests/test_extension_safety.py
@@ -1,16 +1,18 @@
 """Tests for extension naming, dependency validation, and path safety."""
 
+from typing import Any
+
 import pytest
 
 from pyisolate._internal import host
 
 
 class TestNormalizeExtensionName:
-    def test_rejects_empty(self):
+    def test_rejects_empty(self) -> None:
         with pytest.raises(ValueError):
             host.normalize_extension_name("")
 
-    def test_strips_dangerous_chars(self):
+    def test_strips_dangerous_chars(self) -> None:
         name = "../My Extension| rm -rf /"
         normalized = host.normalize_extension_name(name)
         assert ".." not in normalized
@@ -18,37 +20,37 @@ class TestNormalizeExtensionName:
         assert " " not in normalized
         assert normalized == "My_Extension_rm_-rf"
 
-    def test_preserves_unicode_and_collapses_underscores(self):
+    def test_preserves_unicode_and_collapses_underscores(self) -> None:
         name = "你好   世界"
         normalized = host.normalize_extension_name(name)
         assert normalized == "你好_世界"
 
-    def test_raises_when_all_chars_invalid(self):
+    def test_raises_when_all_chars_invalid(self) -> None:
         with pytest.raises(ValueError):
             host.normalize_extension_name("////")
 
 
 class TestValidateDependency:
-    def test_allows_editable_flag(self):
+    def test_allows_editable_flag(self) -> None:
         host.validate_dependency("-e")  # should not raise
 
     @pytest.mark.parametrize(
         "dependency",
         ["--option", "pkg|whoami", "pkg&&evil", "pkg`cmd`"],
     )
-    def test_rejects_dangerous_patterns(self, dependency):
+    def test_rejects_dangerous_patterns(self, dependency: Any) -> None:
         with pytest.raises(ValueError):
             host.validate_dependency(dependency)
 
 
 class TestValidatePathWithinRoot:
-    def test_allows_path_inside_root(self, tmp_path):
+    def test_allows_path_inside_root(self, tmp_path: Any) -> None:
         root = tmp_path
         inside = root / "child" / "module"
         inside.mkdir(parents=True)
         host.validate_path_within_root(inside, root)  # should not raise
 
-    def test_rejects_path_outside_root(self, tmp_path):
+    def test_rejects_path_outside_root(self, tmp_path: Any) -> None:
         root = tmp_path / "root"
         other = tmp_path / "other"
         root.mkdir()

--- a/tests/test_fail_loud.py
+++ b/tests/test_fail_loud.py
@@ -1,9 +1,11 @@
+from typing import Any
+
 import pytest
 
 from pyisolate._internal import bootstrap
 
 
-def test_bootstrap_malformed_snapshot_fails(monkeypatch):
+def test_bootstrap_malformed_snapshot_fails(monkeypatch: Any) -> None:
     """Test that a malformed JSON snapshot raises ValueError."""
     monkeypatch.setenv("PYISOLATE_HOST_SNAPSHOT", "{invalid_json")
 
@@ -11,7 +13,7 @@ def test_bootstrap_malformed_snapshot_fails(monkeypatch):
         bootstrap.bootstrap_child()
 
 
-def test_bootstrap_missing_adapter_ref_fails(monkeypatch):
+def test_bootstrap_missing_adapter_ref_fails(monkeypatch: Any) -> None:
     """Test that valid JSON without adapter_ref returns None (no adapter loaded)."""
     # If no adapter_ref is present, bootstrap returns None, it doesn't fail unless
     # adapter_ref WAS present but failed to load.
@@ -21,7 +23,7 @@ def test_bootstrap_missing_adapter_ref_fails(monkeypatch):
     assert adapter is None
 
 
-def test_bootstrap_bad_adapter_ref_fails(monkeypatch):
+def test_bootstrap_bad_adapter_ref_fails(monkeypatch: Any) -> None:
     """Test that a valid snapshot with a bad adapter_ref logs a warning
     but might not crash unless critical logic depends on it.
     """

--- a/tests/test_host_conda_dispatch.py
+++ b/tests/test_host_conda_dispatch.py
@@ -4,9 +4,29 @@ from __future__ import annotations
 
 import contextlib
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from pyisolate._internal.sandbox_detect import RestrictionModel
+from pyisolate.config import ExtensionConfig
+
+
+def _make_config(**overrides: object) -> ExtensionConfig:
+    config: ExtensionConfig = {
+        "name": "test_ext",
+        "module": "test_module",
+        "dependencies": [],
+        "share_torch": False,
+        "share_cuda_ipc": False,
+        "isolated": True,
+        "apis": [],
+    }
+    return cast(ExtensionConfig, {**config, **overrides})
+
+
+def _call_private_launch(ext: Any) -> Any:
+    return ext._Extension__launch()
+
 
 # ── __launch dispatch ────────────────────────────────────────────────
 
@@ -29,16 +49,11 @@ class TestLaunchDispatchConda:
         from pyisolate._internal.host import Extension
         from pyisolate.shared import ExtensionBase
 
-        config = {
-            "name": "test_ext",
-            "module": "test_module",
-            "dependencies": [],
-            "share_torch": False,
-            "share_cuda_ipc": False,
-            "package_manager": "conda",
-            "conda_channels": ["conda-forge"],
-            "conda_dependencies": ["numpy"],
-        }
+        config = _make_config(
+            package_manager="conda",
+            conda_channels=["conda-forge"],
+            conda_dependencies=["numpy"],
+        )
 
         ext = Extension.__new__(Extension)
         ext.name = "test_ext"
@@ -49,7 +64,7 @@ class TestLaunchDispatchConda:
 
         # Call the private __launch via name mangling
         with patch.object(ext, "_launch_with_uds", return_value=MagicMock()):
-            ext._Extension__launch()
+            _call_private_launch(ext)
 
         mock_create_conda.assert_called_once()
         mock_create_venv.assert_not_called()
@@ -70,14 +85,7 @@ class TestLaunchDispatchConda:
         from pyisolate._internal.host import Extension
         from pyisolate.shared import ExtensionBase
 
-        config = {
-            "name": "test_ext",
-            "module": "test_module",
-            "dependencies": [],
-            "share_torch": False,
-            "share_cuda_ipc": False,
-            "package_manager": "uv",
-        }
+        config = _make_config(package_manager="uv")
 
         ext = Extension.__new__(Extension)
         ext.name = "test_ext"
@@ -87,7 +95,7 @@ class TestLaunchDispatchConda:
         ext.extension_type = ExtensionBase
 
         with patch.object(ext, "_launch_with_uds", return_value=MagicMock()):
-            ext._Extension__launch()
+            _call_private_launch(ext)
 
         mock_create_venv.assert_called_once()
         mock_install_deps.assert_called_once()
@@ -104,16 +112,11 @@ class TestLaunchDispatchConda:
         from pyisolate._internal.host import Extension
         from pyisolate.shared import ExtensionBase
 
-        config = {
-            "name": "test_ext",
-            "module": "test_module",
-            "dependencies": [],
-            "share_torch": False,
-            "share_cuda_ipc": False,
-            "package_manager": "conda",
-            "conda_channels": ["conda-forge"],
-            "conda_dependencies": ["numpy"],
-        }
+        config = _make_config(
+            package_manager="conda",
+            conda_channels=["conda-forge"],
+            conda_dependencies=["numpy"],
+        )
 
         ext = Extension.__new__(Extension)
         ext.name = "test_ext"
@@ -123,7 +126,7 @@ class TestLaunchDispatchConda:
         ext.extension_type = ExtensionBase
 
         with patch.object(ext, "_launch_with_uds", return_value=MagicMock()):
-            ext._Extension__launch()
+            _call_private_launch(ext)
 
         mock_validate.assert_called_once_with(config)
 
@@ -140,14 +143,7 @@ class TestLaunchDispatchConda:
         from pyisolate._internal.host import Extension
         from pyisolate.shared import ExtensionBase
 
-        config = {
-            "name": "test_ext",
-            "module": "test_module",
-            "dependencies": [],
-            "share_torch": False,
-            "share_cuda_ipc": False,
-            "package_manager": "uv",
-        }
+        config = _make_config(package_manager="uv")
 
         ext = Extension.__new__(Extension)
         ext.name = "test_ext"
@@ -157,7 +153,7 @@ class TestLaunchDispatchConda:
         ext.extension_type = ExtensionBase
 
         with patch.object(ext, "_launch_with_uds", return_value=MagicMock()):
-            ext._Extension__launch()
+            _call_private_launch(ext)
 
         mock_validate.assert_called_once_with(config)
 
@@ -173,16 +169,11 @@ class TestPythonExeResolution:
         from pyisolate._internal.host import Extension
         from pyisolate.shared import ExtensionBase
 
-        config = {
-            "name": "test_ext",
-            "module": "test_module",
-            "dependencies": [],
-            "share_torch": False,
-            "share_cuda_ipc": False,
-            "package_manager": "conda",
-            "conda_channels": ["conda-forge"],
-            "conda_dependencies": ["numpy"],
-        }
+        config = _make_config(
+            package_manager="conda",
+            conda_channels=["conda-forge"],
+            conda_dependencies=["numpy"],
+        )
 
         ext = Extension.__new__(Extension)
         ext.name = "test_ext"
@@ -215,7 +206,7 @@ class TestPythonExeResolution:
             # This will fail because we need more mocking, but the key assertion
             # is that _resolve_pixi_python is called for conda backend
             with contextlib.suppress(Exception):
-                ext._launch_with_uds()
+                cast(Any, ext)._launch_with_uds()
 
             mock_resolve.assert_called_once()
 
@@ -233,18 +224,13 @@ class TestCondaSealedWorkerBwrapDispatch:
         from pyisolate._internal.host import Extension
         from pyisolate.shared import ExtensionBase
 
-        config = {
-            "name": "test_ext",
-            "module": "test_module",
-            "dependencies": [],
-            "share_torch": False,
-            "share_cuda_ipc": False,
-            "package_manager": "conda",
-            "execution_model": "sealed_worker",
-            "conda_channels": ["conda-forge"],
-            "conda_dependencies": ["numpy"],
-            "sandbox": {"writable_paths": ["/fake/artifacts"]},
-        }
+        config = _make_config(
+            package_manager="conda",
+            execution_model="sealed_worker",
+            conda_channels=["conda-forge"],
+            conda_dependencies=["numpy"],
+            sandbox={"writable_paths": ["/fake/artifacts"]},
+        )
 
         ext = Extension.__new__(Extension)
         ext.name = "test_ext"
@@ -298,7 +284,7 @@ class TestCondaSealedWorkerBwrapDispatch:
                 patch("pyisolate._internal.host.build_extension_snapshot", return_value={}),
                 patch("os.chmod"),
             ):
-                ext._launch_with_uds()
+                cast(Any, ext)._launch_with_uds()
 
         mock_build_bwrap.assert_called_once()
         kwargs = mock_build_bwrap.call_args.kwargs
@@ -321,18 +307,13 @@ class TestEnvPropagation:
         from pyisolate._internal.host import Extension
         from pyisolate.shared import ExtensionBase
 
-        config = {
-            "name": "test_ext",
-            "module": "test_module",
-            "dependencies": [],
-            "share_torch": False,
-            "share_cuda_ipc": False,
-            "package_manager": "conda",
-            "execution_model": "sealed_worker",
-            "conda_channels": ["conda-forge"],
-            "conda_dependencies": ["boltons"],
-            "env": {"PYISOLATE_ARTIFACT_DIR": r"C:\artifacts"},
-        }
+        config = _make_config(
+            package_manager="conda",
+            execution_model="sealed_worker",
+            conda_channels=["conda-forge"],
+            conda_dependencies=["boltons"],
+            env={"PYISOLATE_ARTIFACT_DIR": r"C:\artifacts"},
+        )
 
         ext = Extension.__new__(Extension)
         ext.name = "test_ext"
@@ -373,7 +354,7 @@ class TestEnvPropagation:
             mock_socket.SOL_SOCKET = 1
             mock_socket.SO_REUSEADDR = 2
 
-            ext._launch_with_uds()
+            cast(Any, ext)._launch_with_uds()
 
         child_env = mock_popen.call_args.kwargs["env"]
         assert child_env["PYISOLATE_ARTIFACT_DIR"] == r"C:\artifacts"
@@ -396,16 +377,12 @@ class TestCondaCudaIpcForced:
         from pyisolate._internal.host import Extension
         from pyisolate.shared import ExtensionBase
 
-        config = {
-            "name": "test_ext",
-            "module": "test_module",
-            "dependencies": [],
-            "share_torch": False,
-            "share_cuda_ipc": True,  # Explicitly set, should be overridden
-            "package_manager": "conda",
-            "conda_channels": ["conda-forge"],
-            "conda_dependencies": ["numpy"],
-        }
+        config = _make_config(
+            share_cuda_ipc=True,
+            package_manager="conda",
+            conda_channels=["conda-forge"],
+            conda_dependencies=["numpy"],
+        )
 
         ext = Extension.__new__(Extension)
         ext.name = "test_ext"
@@ -416,7 +393,7 @@ class TestCondaCudaIpcForced:
         ext._cuda_ipc_enabled = True
 
         with patch.object(ext, "_launch_with_uds", return_value=MagicMock()):
-            ext._Extension__launch()
+            _call_private_launch(ext)
 
         # After __launch, cuda_ipc should be forced False
         assert ext._cuda_ipc_enabled is False

--- a/tests/test_host_integration.py
+++ b/tests/test_host_integration.py
@@ -1,32 +1,34 @@
+from typing import Any
+
 from pyisolate._internal import host
 
 
 class FakeAdapter:
     identifier = "fake"
 
-    def __init__(self, preferred_root="/tmp/ComfyUI"):
+    def __init__(self, preferred_root: Any = "/tmp/ComfyUI") -> None:
         self.preferred_root = preferred_root
 
-    def get_path_config(self, module_path):
+    def get_path_config(self, module_path: Any) -> Any:
         return {
             "preferred_root": self.preferred_root,
             "additional_paths": [f"{self.preferred_root}/custom_nodes"],
         }
 
-    def setup_child_environment(self, snapshot):
+    def setup_child_environment(self, snapshot: Any) -> Any:
         return None
 
-    def register_serializers(self, registry):
+    def register_serializers(self, registry: Any) -> Any:
         return None
 
-    def provide_rpc_services(self):
+    def provide_rpc_services(self) -> Any:
         return []
 
-    def handle_api_registration(self, api, rpc):
+    def handle_api_registration(self, api: Any, rpc: Any) -> Any:
         return None
 
 
-def test_build_extension_snapshot_includes_adapter(monkeypatch):
+def test_build_extension_snapshot_includes_adapter(monkeypatch: Any) -> None:
     from pyisolate._internal.adapter_registry import AdapterRegistry
 
     monkeypatch.setattr(AdapterRegistry, "get", lambda: FakeAdapter())
@@ -35,12 +37,16 @@ def test_build_extension_snapshot_includes_adapter(monkeypatch):
 
     assert "sys_path" in snapshot
     assert snapshot["adapter_name"] == "fake"
-    assert snapshot["preferred_root"].endswith("ComfyUI")
+    preferred_root = snapshot["preferred_root"]
+    assert isinstance(preferred_root, str)
+    assert preferred_root.endswith("ComfyUI")
     assert snapshot.get("additional_paths")
-    assert snapshot.get("context_data", {}).get("module_path") == "/tmp/ComfyUI/custom_nodes/demo"
+    context_data = snapshot.get("context_data", {})
+    assert isinstance(context_data, dict)
+    assert context_data.get("module_path") == "/tmp/ComfyUI/custom_nodes/demo"
 
 
-def test_build_extension_snapshot_no_adapter(monkeypatch):
+def test_build_extension_snapshot_no_adapter(monkeypatch: Any) -> None:
     from pyisolate._internal.adapter_registry import AdapterRegistry
 
     monkeypatch.setattr(AdapterRegistry, "get", lambda: None)

--- a/tests/test_host_internal_ext.py
+++ b/tests/test_host_internal_ext.py
@@ -1,119 +1,127 @@
+import asyncio
+import logging
 import queue
+import socket
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
 from pyisolate._internal import host
 from pyisolate._internal.host import Extension
+from pyisolate._internal.rpc_protocol import AsyncRPC, ProxiedSingleton
+from pyisolate._internal.rpc_transports import JSONSocketTransport
 from pyisolate._internal.sandbox_detect import RestrictionModel, SandboxCapability
+from pyisolate.config import ExtensionConfig
 
 
 class DummyRPC:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.run_called = False
 
-    def register_callee(self, obj, object_id):
+    def register_callee(self, obj: Any, object_id: Any) -> None:
         pass
 
-    def run(self):
+    def run(self) -> None:
         self.run_called = True
 
 
 class DummyProcess:
-    def __init__(self):
+    def __init__(self) -> None:
         self.alive = False
 
-    def start(self):
+    def start(self) -> None:
         self.alive = True
 
-    def is_alive(self):
+    def is_alive(self) -> Any:
         return self.alive
 
-    def terminate(self):
+    def terminate(self) -> None:
         self.alive = False
 
-    def join(self, timeout=None):
+    def join(self, timeout: Any = None) -> None:
         self.alive = False
 
-    def kill(self):
+    def kill(self) -> None:
         self.alive = False
 
 
 class DummyContext:
-    def __init__(self):
-        self.q = queue.Queue()
+    def __init__(self) -> None:
+        self.q: queue.Queue[Any] = queue.Queue()
 
-    def Queue(self):  # noqa: N802 - matches multiprocessing API
+    def Queue(self) -> Any:  # noqa: N802 - matches multiprocessing API
         return queue.Queue()
 
-    def Process(self, target, args):  # noqa: N802 - matches multiprocessing API
+    def Process(self, target: Any, args: Any) -> Any:  # noqa: N802 - matches multiprocessing API
         return DummyProcess()
 
 
 class DummyMP:
-    def __init__(self):
+    def __init__(self) -> None:
         self.ctx = DummyContext()
         self.executable = None
 
-    def get_context(self, mode):
+    def get_context(self, mode: Any) -> Any:
         return self.ctx
 
-    def set_executable(self, exe):
+    def set_executable(self, exe: Any) -> None:
         self.executable = exe
 
 
 class DummyExtension(Extension):
-    def __init__(self, tmp_path: Path, config_overrides=None):
-        base_config = {
+    def __init__(self, tmp_path: Path, config_overrides: Any = None) -> None:
+        base_config: dict[str, Any] = {
             "name": "demo",
+            "isolated": True,
             "dependencies": [],
             "share_torch": True,
             "share_cuda_ipc": False,
             "apis": [],
         }
         if config_overrides:
-            base_config.update(config_overrides)
+            base_config.update(cast(dict[str, Any], config_overrides))
         super().__init__(
             module_path="/tmp/mod.py",
             extension_type=SimpleNamespace,
-            config=base_config,
+            config=cast(ExtensionConfig, base_config),
             venv_root_path=str(tmp_path),
         )
         # patch multiprocessing
         self.mp = DummyMP()
 
-    def _create_extension_venv(self):
+    def _create_extension_venv(self) -> None:
         # skip actual venv creation
         return
 
-    def _install_dependencies(self):
+    def _install_dependencies(self) -> None:
         return
 
-    def __launch(self):
+    def __launch(self) -> Any:
         return DummyProcess()
 
 
 @pytest.fixture(autouse=True)
-def reset_env(monkeypatch):
+def reset_env(monkeypatch: Any) -> None:
     monkeypatch.delenv("PYISOLATE_ENABLE_CUDA_IPC", raising=False)
     monkeypatch.delenv("PYISOLATE_CHILD", raising=False)
 
 
-def test_initialize_process_requires_share_torch_for_cuda_ipc(tmp_path):
+def test_initialize_process_requires_share_torch_for_cuda_ipc(tmp_path: Any) -> None:
     ext = DummyExtension(tmp_path, {"share_torch": False, "share_cuda_ipc": True})
     with pytest.raises(RuntimeError):
         ext._initialize_process()
 
 
-def test_initialize_process_cuda_ipc_unavailable_raises(monkeypatch, tmp_path):
+def test_initialize_process_cuda_ipc_unavailable_raises(monkeypatch: Any, tmp_path: Any) -> Any:
     ext = DummyExtension(tmp_path, {"share_torch": True, "share_cuda_ipc": True})
     from pyisolate._internal import torch_utils
 
     monkeypatch.setattr(torch_utils, "probe_cuda_ipc_support", lambda: (False, "no"))
 
-    def mock_launch():
+    def mock_launch() -> Any:
         if ext.config.get("share_cuda_ipc"):
             supported, reason = torch_utils.probe_cuda_ipc_support()
             if not supported:
@@ -127,35 +135,35 @@ def test_initialize_process_cuda_ipc_unavailable_raises(monkeypatch, tmp_path):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="AF_UNIX monkeypatch requires Linux")
-def test_initialize_process_sets_env_and_runs_rpc(monkeypatch, tmp_path):
+def test_initialize_process_sets_env_and_runs_rpc(monkeypatch: Any, tmp_path: Any) -> Any:
     ext = DummyExtension(tmp_path, {"share_torch": True, "share_cuda_ipc": False})
     monkeypatch.setattr(host, "AsyncRPC", lambda recv_queue=None, send_queue=None, transport=None: DummyRPC())
 
     class MockPopen:
-        def __init__(self, cmd, **kwargs):
+        def __init__(self, cmd: Any, **kwargs: Any) -> None:
             self.args = cmd
             self.env = kwargs.get("env", {})
             self.returncode = None
 
-        def poll(self):
+        def poll(self) -> Any:
             return None
 
-        def terminate(self):
+        def terminate(self) -> None:
             pass
 
-        def kill(self):
+        def kill(self) -> None:
             pass
 
-        def wait(self, timeout=None):
+        def wait(self, timeout: Any = None) -> Any:
             return 0
 
-        def __enter__(self):
+        def __enter__(self) -> Any:
             return self
 
-        def __exit__(self, *args):
+        def __exit__(self, *args: Any) -> None:
             pass
 
-        def communicate(self, input=None, timeout=None):
+        def communicate(self, input: Any = None, timeout: Any = None) -> Any:
             return (b"", b"")
 
     monkeypatch.setattr(host.subprocess, "Popen", MockPopen)
@@ -174,28 +182,28 @@ def test_initialize_process_sets_env_and_runs_rpc(monkeypatch, tmp_path):
     )
 
     class MockSocket:
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
             pass
 
-        def bind(self, path):
+        def bind(self, path: Any) -> None:
             pass
 
-        def listen(self, backlog):
+        def listen(self, backlog: Any) -> None:
             pass
 
-        def accept(self):
+        def accept(self) -> Any:
             return (MockSocket(), "addr")
 
-        def close(self):
+        def close(self) -> None:
             pass
 
-        def sendall(self, data):
+        def sendall(self, data: Any) -> None:
             pass
 
-        def recv(self, n):
+        def recv(self, n: Any) -> Any:
             return b""
 
-        def shutdown(self, how):
+        def shutdown(self, how: Any) -> None:
             pass
 
     monkeypatch.setattr(host.socket, "socket", MockSocket)
@@ -205,16 +213,16 @@ def test_initialize_process_sets_env_and_runs_rpc(monkeypatch, tmp_path):
     monkeypatch.setattr(host.os, "chmod", lambda path, mode, **kwargs: None)
 
     class MockTransport:
-        def __init__(self, sock):
+        def __init__(self, sock: Any) -> None:
             pass
 
-        def send(self, data):
+        def send(self, data: Any) -> None:
             pass
 
-        def recv(self):
+        def recv(self) -> Any:
             return {}
 
-        def close(self):
+        def close(self) -> None:
             pass
 
     monkeypatch.setattr(host, "JSONSocketTransport", MockTransport)
@@ -238,7 +246,7 @@ def test_initialize_process_sets_env_and_runs_rpc(monkeypatch, tmp_path):
     assert ext.rpc.run_called is True
 
 
-def test_install_dependencies_no_deps_returns(monkeypatch, tmp_path):
+def test_install_dependencies_no_deps_returns(monkeypatch: Any, tmp_path: Any) -> None:
     ext = DummyExtension(tmp_path)
     # ensure python exe exists
     venv_bin = Path(ext.venv_path / "bin")
@@ -248,7 +256,7 @@ def test_install_dependencies_no_deps_returns(monkeypatch, tmp_path):
     ext._install_dependencies()
 
 
-def test_probe_cuda_ipc_support_handles_import_error(monkeypatch):
+def test_probe_cuda_ipc_support_handles_import_error(monkeypatch: Any) -> None:
     from pyisolate._internal import torch_utils
 
     monkeypatch.setattr(torch_utils.sys, "platform", "linux")
@@ -258,7 +266,7 @@ def test_probe_cuda_ipc_support_handles_import_error(monkeypatch):
     assert "torch import failed" in reason
 
 
-def test_install_dependencies_respects_lock_cache(monkeypatch, tmp_path):
+def test_install_dependencies_respects_lock_cache(monkeypatch: Any, tmp_path: Any) -> None:
     ext = DummyExtension(tmp_path)
     venv_bin = Path(ext.venv_path / "bin")
     venv_bin.mkdir(parents=True, exist_ok=True)
@@ -283,3 +291,43 @@ def test_install_dependencies_respects_lock_cache(monkeypatch, tmp_path):
 
     # should return early without invoking pip/uv
     ext._install_dependencies()
+
+
+def test_callable_roundtrip_shutdown_is_clean(caplog: Any, capsys: Any) -> Any:
+    class HostCallbackAPI(ProxiedSingleton):
+        async def invoke(self, handler: Any, payload: Any) -> Any:
+            return await handler(payload)
+
+    async def scenario() -> Any:
+        left, right = socket.socketpair()
+        host_transport = JSONSocketTransport(left)
+        child_transport = JSONSocketTransport(right)
+        host_rpc = AsyncRPC(transport=host_transport)
+        child_rpc = AsyncRPC(transport=child_transport)
+        HostCallbackAPI()._register(host_rpc)
+        host_rpc.run()
+        child_rpc.run()
+        caller = child_rpc.create_caller(HostCallbackAPI, HostCallbackAPI.get_remote_id())
+
+        try:
+
+            def handler(payload: Any) -> Any:
+                return {"value": payload["value"] + 1}
+
+            result = await asyncio.wait_for(caller.invoke(handler, {"value": 41}), timeout=5)
+            return result
+        finally:
+            child_rpc.shutdown()
+            host_rpc.shutdown()
+            await asyncio.sleep(0)
+            child_transport.close()
+            host_transport.close()
+            await asyncio.sleep(0)
+
+    with caplog.at_level(logging.ERROR):
+        result = asyncio.run(scenario())
+
+    captured = capsys.readouterr()
+    assert result == {"value": 42}
+    assert "InvalidStateError" not in captured.err
+    assert "RPC recv failed" not in caplog.text

--- a/tests/test_host_public.py
+++ b/tests/test_host_public.py
@@ -8,7 +8,7 @@ from pyisolate.host import ExtensionManager
 
 class FakeExtension:
     @classmethod
-    def __class_getitem__(cls, item):
+    def __class_getitem__(cls, item: Any) -> Any:
         return cls
 
     def __init__(
@@ -28,23 +28,23 @@ class FakeExtension:
         self.started += 1
         self._process_initialized = True
 
-    def get_proxy(self):
+    def get_proxy(self) -> Any:
         return self.proxy_obj
 
-    def stop(self):
+    def stop(self) -> None:
         self.stopped += 1
 
 
 @pytest.fixture(autouse=True)
-def patch_extension(monkeypatch):
+def patch_extension(monkeypatch: Any) -> None:
     monkeypatch.setattr("pyisolate.host.Extension", FakeExtension)
 
 
-def make_manager(tmp_path):
+def make_manager(tmp_path: Any) -> Any:
     return ExtensionManager(types.SimpleNamespace, {"venv_root_path": str(tmp_path)})
 
 
-def base_config(tmp_path):
+def base_config(tmp_path: Any) -> Any:
     return {
         "name": "demo",
         "module_path": "/tmp/mod.py",
@@ -56,7 +56,7 @@ def base_config(tmp_path):
     }
 
 
-def test_load_extension_returns_host_extension(monkeypatch, tmp_path):
+def test_load_extension_returns_host_extension(monkeypatch: Any, tmp_path: Any) -> None:
     mgr = make_manager(tmp_path)
     proxy = mgr.load_extension(base_config(tmp_path))
     # First access triggers start + rpc init + proxy creation
@@ -69,7 +69,7 @@ def test_load_extension_returns_host_extension(monkeypatch, tmp_path):
     assert ext.started == 1
 
 
-def test_duplicate_extension_name_raises(tmp_path):
+def test_duplicate_extension_name_raises(tmp_path: Any) -> None:
     mgr = make_manager(tmp_path)
     cfg = base_config(tmp_path)
     mgr.load_extension(cfg)
@@ -77,7 +77,7 @@ def test_duplicate_extension_name_raises(tmp_path):
         mgr.load_extension(cfg)
 
 
-def test_host_extension_getattr_delegates(monkeypatch, tmp_path):
+def test_host_extension_getattr_delegates(monkeypatch: Any, tmp_path: Any) -> None:
     mgr = make_manager(tmp_path)
     cfg = base_config(tmp_path)
     proxy = mgr.load_extension(cfg)
@@ -89,7 +89,7 @@ def test_host_extension_getattr_delegates(monkeypatch, tmp_path):
     assert proxy.run() == "ok"
 
 
-def test_stop_all_extensions_calls_stop(tmp_path):
+def test_stop_all_extensions_calls_stop(tmp_path: Any) -> None:
     mgr = make_manager(tmp_path)
     cfg = base_config(tmp_path)
     mgr.load_extension(cfg)
@@ -98,13 +98,13 @@ def test_stop_all_extensions_calls_stop(tmp_path):
     assert mgr.extensions == {}
 
 
-def test_stop_all_extensions_logs_error(caplog, tmp_path):
+def test_stop_all_extensions_logs_error(caplog: Any, tmp_path: Any) -> None:
     mgr = make_manager(tmp_path)
     cfg = base_config(tmp_path)
     _proxy = mgr.load_extension(cfg)  # noqa: F841 - load to register extension
     ext = mgr.extensions["demo"]
 
-    def boom():
+    def boom() -> None:
         raise RuntimeError("boom")
 
     ext.stop = boom  # type: ignore[assignment]

--- a/tests/test_host_sealed_worker_dispatch.py
+++ b/tests/test_host_sealed_worker_dispatch.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from pyisolate._internal.sandbox_detect import RestrictionModel
+from pyisolate.config import ExtensionConfig
 
 
-def _make_extension(config: dict[str, object]):
+def _make_extension(config: ExtensionConfig) -> Any:
     from pyisolate._internal.host import Extension
     from pyisolate.shared import ExtensionBase
 
@@ -41,10 +43,12 @@ class TestLaunchDispatchSealedWorker:
         mock_create_conda: MagicMock,
         mock_validate: MagicMock,
     ) -> None:
-        config = {
+        config: ExtensionConfig = {
             "name": "test_ext",
             "module": "test_module",
+            "isolated": True,
             "dependencies": [],
+            "apis": [],
             "share_torch": False,
             "share_cuda_ipc": False,
             "package_manager": "uv",
@@ -62,10 +66,12 @@ class TestLaunchDispatchSealedWorker:
         mock_create_conda.assert_not_called()
 
     def test_uv_sealed_worker_uses_json_tensor_transport(self) -> None:
-        config = {
+        config: ExtensionConfig = {
             "name": "test_ext",
             "module": "test_module",
+            "isolated": True,
             "dependencies": [],
+            "apis": [],
             "share_torch": False,
             "share_cuda_ipc": False,
             "package_manager": "uv",
@@ -83,10 +89,12 @@ class TestLaunchDispatchSealedWorker:
         mock_popen: MagicMock,
         mock_build_bwrap: MagicMock,
     ) -> None:
-        config = {
+        config: ExtensionConfig = {
             "name": "test_ext",
             "module": "test_module",
+            "isolated": True,
             "dependencies": [],
+            "apis": [],
             "share_torch": False,
             "share_cuda_ipc": False,
             "package_manager": "uv",
@@ -149,10 +157,12 @@ class TestLaunchDispatchSealedWorker:
         assert bootstrap_data["snapshot"]["apply_host_sys_path"] is False
 
     def test_uv_host_coupled_keeps_shared_memory_tensor_transport(self) -> None:
-        config = {
+        config: ExtensionConfig = {
             "name": "test_ext",
             "module": "test_module",
+            "isolated": True,
             "dependencies": [],
+            "apis": [],
             "share_torch": False,
             "share_cuda_ipc": False,
             "package_manager": "uv",

--- a/tests/test_memory_leaks.py
+++ b/tests/test_memory_leaks.py
@@ -12,6 +12,7 @@ For actual memory profiling, use tracemalloc in integration tests.
 import gc
 import time
 import weakref
+from typing import Any
 
 import pytest
 
@@ -21,11 +22,11 @@ from pyisolate._internal.rpc_protocol import ProxiedSingleton, SingletonMetaclas
 class TestProxyGarbageCollection:
     """Tests for proxy object garbage collection."""
 
-    def test_proxy_gc_after_singleton_clear(self):
+    def test_proxy_gc_after_singleton_clear(self) -> None:
         """Verify ProxiedSingleton instances can be garbage collected."""
 
         class TestService(ProxiedSingleton):
-            def __init__(self):
+            def __init__(self) -> None:
                 super().__init__()
                 self.data = "test"
 
@@ -47,16 +48,16 @@ class TestProxyGarbageCollection:
         # Instance should be collected
         assert weak_ref() is None, "Singleton not collected after clearing registry"
 
-    def test_nested_singleton_gc(self):
+    def test_nested_singleton_gc(self) -> None:
         """Verify nested singletons are properly collected."""
 
         class ChildService(ProxiedSingleton):
-            def __init__(self):
+            def __init__(self) -> None:
                 super().__init__()
-                self.data = []
+                self.data: list[Any] = []
 
         class ParentService(ProxiedSingleton):
-            def __init__(self):
+            def __init__(self) -> None:
                 super().__init__()
                 self.child = ChildService()
 
@@ -85,25 +86,23 @@ class TestTensorKeeperCleanup:
     """Tests for TensorKeeper memory management."""
 
     @pytest.fixture
-    def fast_tensor_keeper(self, monkeypatch):
+    def fast_tensor_keeper(self, monkeypatch: Any) -> None:
         """Configure TensorKeeper with short retention for testing."""
         from pyisolate._internal.tensor_serializer import TensorKeeper
+
+        def fast_init(self: Any, retention_seconds: float = 2.0) -> None:  # noqa: ARG001
+            self.retention_seconds = 2.0
+            self._keeper = __import__("collections").deque()
+            self._lock = __import__("threading").Lock()
 
         # Use 2 second retention for fast testing
         monkeypatch.setattr(
             TensorKeeper,
             "__init__",
-            lambda self, retention_seconds=2.0: (
-                (
-                    setattr(self, "retention_seconds", 2.0),
-                    setattr(self, "_keeper", __import__("collections").deque()),
-                    setattr(self, "_lock", __import__("threading").Lock()),
-                )[-1]
-                or None
-            ),
+            fast_init,
         )
 
-    def test_tensor_keeper_keeps_reference(self):
+    def test_tensor_keeper_keeps_reference(self) -> None:
         """Verify TensorKeeper holds tensor reference."""
         pytest.importorskip("torch")
         import torch
@@ -125,7 +124,7 @@ class TestTensorKeeperCleanup:
         assert weak_ref() is not None, "Tensor collected while keeper holds it"
 
     @pytest.mark.slow
-    def test_tensor_keeper_releases_after_timeout(self):
+    def test_tensor_keeper_releases_after_timeout(self) -> None:
         """Verify TensorKeeper releases tensors after retention period.
 
         Note: This test takes ~3 seconds due to retention timeout.
@@ -165,13 +164,13 @@ class TestTensorKeeperCleanup:
 class TestRegistryCleanup:
     """Tests for registry refcount and cleanup."""
 
-    def test_singleton_registry_refcount(self):
+    def test_singleton_registry_refcount(self) -> None:
         """Verify singleton instances are tracked in registry."""
 
         class CountedService(ProxiedSingleton):
             instances_created = 0
 
-            def __init__(self):
+            def __init__(self) -> None:
                 super().__init__()
                 CountedService.instances_created += 1
 
@@ -189,7 +188,7 @@ class TestRegistryCleanup:
         SingletonMetaclass._instances.clear()
         assert CountedService not in SingletonMetaclass._instances
 
-    def test_registry_cleanup_on_instance_delete(self):
+    def test_registry_cleanup_on_instance_delete(self) -> None:
         """Verify registry doesn't prevent GC when manually cleared."""
 
         class TrackedService(ProxiedSingleton):
@@ -220,18 +219,18 @@ class TestRegistryCleanup:
 class TestMemoryLeakScenarios:
     """Tests for specific memory leak scenarios."""
 
-    def test_circular_reference_singleton(self):
+    def test_circular_reference_singleton(self) -> None:
         """Verify circular references don't prevent collection."""
 
         class NodeA(ProxiedSingleton):
-            def __init__(self):
+            def __init__(self) -> None:
                 super().__init__()
-                self.ref = None
+                self.ref: NodeB | None = None
 
         class NodeB(ProxiedSingleton):
-            def __init__(self):
+            def __init__(self) -> None:
                 super().__init__()
-                self.ref = None
+                self.ref: NodeA | None = None
 
         # Create circular reference
         a = NodeA()
@@ -254,11 +253,11 @@ class TestMemoryLeakScenarios:
         assert weak_a() is None, "NodeA not collected (circular ref)"
         assert weak_b() is None, "NodeB not collected (circular ref)"
 
-    def test_exception_during_init_no_leak(self):
+    def test_exception_during_init_no_leak(self) -> None:
         """Verify exceptions during __init__ don't leak memory."""
 
         class FailingService(ProxiedSingleton):
-            def __init__(self):
+            def __init__(self) -> None:
                 super().__init__()
                 raise ValueError("Init failed")
 

--- a/tests/test_memory_leaks.py
+++ b/tests/test_memory_leaks.py
@@ -85,7 +85,7 @@ class TestProxyGarbageCollection:
 class TestTensorKeeperCleanup:
     """Tests for TensorKeeper memory management."""
 
-    @pytest.fixture
+    @pytest.fixture(autouse=True)
     def fast_tensor_keeper(self, monkeypatch: Any) -> None:
         """Configure TensorKeeper with short retention for testing."""
         from pyisolate._internal.tensor_serializer import TensorKeeper

--- a/tests/test_path_helpers_contract.py
+++ b/tests/test_path_helpers_contract.py
@@ -12,28 +12,28 @@ from pyisolate import path_helpers
 class TestSerializeHostSnapshot:
     """Tests for serialize_host_snapshot function."""
 
-    def test_snapshot_includes_sys_path(self):
+    def test_snapshot_includes_sys_path(self) -> None:
         """Snapshot includes current sys.path."""
         snapshot = path_helpers.serialize_host_snapshot()
 
         assert "sys_path" in snapshot
         assert isinstance(snapshot["sys_path"], list)
 
-    def test_snapshot_includes_env_vars(self):
+    def test_snapshot_includes_env_vars(self) -> None:
         """Snapshot includes environment variables."""
         snapshot = path_helpers.serialize_host_snapshot()
 
         assert "environment" in snapshot
         assert isinstance(snapshot["environment"], dict)
 
-    def test_snapshot_paths_are_strings(self):
+    def test_snapshot_paths_are_strings(self) -> None:
         """All paths in snapshot are strings."""
         snapshot = path_helpers.serialize_host_snapshot()
 
         for path in snapshot["sys_path"]:
             assert isinstance(path, str)
 
-    def test_snapshot_is_json_serializable(self):
+    def test_snapshot_is_json_serializable(self) -> None:
         """Snapshot can be JSON serialized."""
         import json
 
@@ -51,7 +51,7 @@ class TestSerializeHostSnapshot:
 class TestBuildChildSysPath:
     """Tests for build_child_sys_path function."""
 
-    def test_host_paths_preserved(self):
+    def test_host_paths_preserved(self) -> None:
         """Host paths are included in output."""
         host = ["/app/root", "/app/lib"]
 
@@ -64,7 +64,7 @@ class TestBuildChildSysPath:
             # Paths may be normalized
             assert any(os.path.normpath(path) in os.path.normpath(r) for r in result)
 
-    def test_extra_paths_included(self):
+    def test_extra_paths_included(self) -> None:
         """Extra paths are included in output."""
         host = ["/app/root"]
         extra = ["/app/venv/site-packages"]
@@ -77,7 +77,7 @@ class TestBuildChildSysPath:
         # Extra paths should appear somewhere
         assert len(result) >= len(host)
 
-    def test_preferred_root_comes_first(self):
+    def test_preferred_root_comes_first(self) -> None:
         """Preferred root is prepended to path list."""
         host = ["/app/lib", "/app/utils"]
         preferred = "/app/root"
@@ -91,7 +91,7 @@ class TestBuildChildSysPath:
         # Preferred root should be first
         assert result[0] == preferred
 
-    def test_no_duplicates(self):
+    def test_no_duplicates(self) -> None:
         """Duplicate paths are removed."""
         host = ["/app/root", "/app/lib", "/app/root"]  # Duplicate
 
@@ -104,7 +104,7 @@ class TestBuildChildSysPath:
         normalized = [os.path.normpath(p) for p in result]
         assert len(normalized) == len(set(normalized))
 
-    def test_returns_list(self):
+    def test_returns_list(self) -> None:
         """Function returns a list."""
         result = path_helpers.build_child_sys_path(
             host_paths=["/app"],
@@ -113,7 +113,7 @@ class TestBuildChildSysPath:
 
         assert isinstance(result, list)
 
-    def test_empty_inputs_handled(self):
+    def test_empty_inputs_handled(self) -> None:
         """Empty inputs don't cause errors."""
         result = path_helpers.build_child_sys_path(
             host_paths=[],

--- a/tests/test_pixi_provisioner.py
+++ b/tests/test_pixi_provisioner.py
@@ -1,0 +1,244 @@
+"""Tests for pixi binary auto-provisioner."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import platform
+import tarfile
+import tempfile
+import zipfile
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyisolate._internal.pixi_provisioner import (
+    PIXI_VERSION,
+    _archive_extension,
+    _binary_name,
+    _get_target,
+    _release_url,
+    _verify_checksum,
+    ensure_pixi,
+)
+
+
+class TestGetTarget:
+    def test_linux_x86_64(self) -> None:
+        with patch("platform.system", return_value="Linux"), patch("platform.machine", return_value="x86_64"):
+            assert _get_target() == "x86_64-unknown-linux-musl"
+
+    def test_darwin_arm64(self) -> None:
+        with patch("platform.system", return_value="Darwin"), patch("platform.machine", return_value="arm64"):
+            assert _get_target() == "aarch64-apple-darwin"
+
+    def test_unsupported_raises(self) -> None:
+        with (
+            patch("platform.system", return_value="FreeBSD"),
+            patch("platform.machine", return_value="sparc"),
+            pytest.raises(RuntimeError, match="Unsupported platform"),
+        ):
+            _get_target()
+
+
+class TestPlatformCoverage:
+    """All 5 supported platform/arch combinations."""
+
+    @pytest.mark.parametrize(
+        "system,machine,expected_target",
+        [
+            ("Linux", "x86_64", "x86_64-unknown-linux-musl"),
+            ("Linux", "aarch64", "aarch64-unknown-linux-musl"),
+            ("Darwin", "x86_64", "x86_64-apple-darwin"),
+            ("Darwin", "arm64", "aarch64-apple-darwin"),
+            ("Windows", "AMD64", "x86_64-pc-windows-msvc"),
+        ],
+    )
+    def test_platform_target_string(self, system: Any, machine: Any, expected_target: Any) -> None:
+        with patch("platform.system", return_value=system), patch("platform.machine", return_value=machine):
+            result = _get_target()
+            assert result == expected_target
+            print(f"PLATFORM={system}/{machine} TARGET={result}")
+
+    def test_windows_binary_name(self, tmp_path: Any) -> None:
+        """ensure_pixi() uses pixi.exe on Windows."""
+        version = PIXI_VERSION
+        cache = tmp_path / "pyisolate" / "pixi" / version
+        cache.mkdir(parents=True)
+        cached_bin = cache / "pixi.exe"
+        cached_bin.write_bytes(b"fake windows binary")
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch("platform.system", return_value="Windows"),
+            patch("platform.machine", return_value="AMD64"),
+            patch("pyisolate._internal.pixi_provisioner._cache_dir", return_value=cache),
+        ):
+            result = ensure_pixi(version)
+            assert result == str(cached_bin)
+            assert result.endswith("pixi.exe")
+            print(f"WINDOWS_BINARY_PATH={result}")
+
+    @pytest.mark.parametrize(
+        "system,machine,expected_target",
+        [
+            ("Linux", "x86_64", "x86_64-unknown-linux-musl"),
+            ("Linux", "aarch64", "aarch64-unknown-linux-musl"),
+            ("Darwin", "x86_64", "x86_64-apple-darwin"),
+            ("Darwin", "arm64", "aarch64-apple-darwin"),
+            ("Windows", "AMD64", "x86_64-pc-windows-msvc"),
+        ],
+    )
+    def test_url_construction(self, system: Any, machine: Any, expected_target: Any) -> None:
+        """Download URL matches GitHub release asset naming convention."""
+        with patch("platform.system", return_value=system), patch("platform.machine", return_value=machine):
+            url = _release_url(PIXI_VERSION, _get_target())
+            ext = ".zip" if system == "Windows" else ".tar.gz"
+            expected_url = (
+                f"https://github.com/prefix-dev/pixi/releases/download/v{PIXI_VERSION}/"
+                f"pixi-{expected_target}{ext}"
+            )
+            assert url == expected_url
+            print(f"URL={url}")
+
+
+class TestVerifyChecksum:
+    def test_valid_checksum(self) -> None:
+        data = b"test binary content"
+        expected = hashlib.sha256(data).hexdigest()
+        _verify_checksum(data, expected)
+
+    def test_invalid_checksum_raises(self) -> None:
+        data = b"test binary content"
+        with pytest.raises(RuntimeError, match="checksum"):
+            _verify_checksum(data, "0" * 64)
+
+
+class TestEnsurePixi:
+    def test_returns_path_on_system(self, tmp_path: Any) -> None:
+        """If pixi is on PATH and version matches, return that path."""
+        fake_pixi = tmp_path / "pixi"
+        fake_pixi.touch()
+        fake_pixi.chmod(0o755)
+
+        with patch("shutil.which", return_value=str(fake_pixi)), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=f"pixi {PIXI_VERSION}\n")
+            result = ensure_pixi()
+            assert result == str(fake_pixi)
+            print(f"RESOLVED_PATH={result}")
+
+    def test_returns_cached_binary(self, tmp_path: Any) -> None:
+        """If cached binary exists, return it without downloading."""
+        version = PIXI_VERSION
+        cache = tmp_path / "pyisolate" / "pixi" / version
+        cache.mkdir(parents=True)
+        cached_bin = cache / _binary_name()
+        cached_bin.write_bytes(b"cached binary")
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch("pyisolate._internal.pixi_provisioner._cache_dir", return_value=cache),
+        ):
+            result = ensure_pixi(version)
+            assert result == str(cached_bin)
+
+    def test_cache_hit_no_http(self, tmp_path: Any) -> None:
+        """ensure_pixi called twice: second call makes zero HTTP requests."""
+        version = PIXI_VERSION
+        cache = tmp_path / "pyisolate" / "pixi" / version
+        cache.mkdir(parents=True)
+        cached_bin = cache / _binary_name()
+        cached_bin.write_bytes(b"cached binary")
+
+        fetch_mock = MagicMock()
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch("pyisolate._internal.pixi_provisioner._cache_dir", return_value=cache),
+            patch("pyisolate._internal.pixi_provisioner._fetch_url", fetch_mock),
+        ):
+            # First call — cache hit, no fetch
+            result1 = ensure_pixi(version)
+            assert result1 == str(cached_bin)
+            assert fetch_mock.call_count == 0
+
+            # Second call — still cache hit
+            result2 = ensure_pixi(version)
+            assert result2 == str(cached_bin)
+            assert fetch_mock.call_count == 0
+            print("HTTP_REQUESTS_ON_SECOND_CALL=0")
+
+    def test_corrupted_download_raises(self, tmp_path: Any) -> None:
+        """Corrupted download triggers checksum RuntimeError."""
+        version = PIXI_VERSION
+        cache = tmp_path / "pyisolate" / "pixi" / version
+
+        # Simulate: no pixi on PATH, no cache, download gives bad data
+        archive_name = f"pixi{_archive_extension()}"
+        with (
+            patch("shutil.which", return_value=None),
+            patch("pyisolate._internal.pixi_provisioner._cache_dir", return_value=cache),
+            patch("pyisolate._internal.pixi_provisioner._fetch_url") as fetch_mock,
+        ):
+            # First call returns checksum, second returns tarball with wrong content
+            good_hash = hashlib.sha256(b"good data").hexdigest()
+            fetch_mock.side_effect = [
+                f"{good_hash}  {archive_name}".encode(),  # checksum file
+                b"corrupted tarball data",  # tarball (wrong content)
+            ]
+
+            with pytest.raises(RuntimeError, match="checksum"):
+                ensure_pixi(version)
+
+    def test_downloads_and_caches(self, tmp_path: Any) -> None:
+        """Full download path: fetch, verify, extract, cache."""
+        version = PIXI_VERSION
+        cache = tmp_path / "pyisolate" / "pixi" / version
+
+        # Create a real archive with a fake pixi binary.
+        fake_binary = b"#!/bin/sh\necho pixi"
+        binary_name = _binary_name()
+        archive_extension = _archive_extension()
+        with closing(tempfile.NamedTemporaryFile(suffix=archive_extension, delete=False)) as archive_buf:
+            archive_path = Path(archive_buf.name)
+        if platform.system() == "Windows":
+            with zipfile.ZipFile(archive_path, "w") as zf:
+                zf.writestr(binary_name, fake_binary)
+        else:
+            with tarfile.open(archive_path, "w:gz") as tf:
+                info = tarfile.TarInfo(name=binary_name)
+                info.size = len(fake_binary)
+                info.mode = 0o755
+                tf.addfile(info, io.BytesIO(fake_binary))
+
+        archive_data = archive_path.read_bytes()
+        os.unlink(archive_path)
+
+        archive_hash = hashlib.sha256(archive_data).hexdigest()
+        archive_name = f"pixi{archive_extension}"
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch("pyisolate._internal.pixi_provisioner._cache_dir", return_value=cache),
+            patch("pyisolate._internal.pixi_provisioner._fetch_url") as fetch_mock,
+        ):
+            fetch_mock.side_effect = [
+                f"{archive_hash}  {archive_name}".encode(),
+                archive_data,
+            ]
+            result = ensure_pixi(version)
+            assert Path(result).exists()
+            assert Path(result).read_bytes() == fake_binary
+            print(f"RESOLVED_PATH={result}")
+
+
+class TestVersionPin:
+    def test_version_is_pinned(self) -> None:
+        """PIXI_VERSION is a hardcoded string, not dynamic."""
+        assert isinstance(PIXI_VERSION, str)
+        assert len(PIXI_VERSION.split(".")) >= 2
+        assert PIXI_VERSION == "0.67.0"

--- a/tests/test_pixi_provisioner.py
+++ b/tests/test_pixi_provisioner.py
@@ -235,6 +235,43 @@ class TestEnsurePixi:
             assert Path(result).read_bytes() == fake_binary
             print(f"RESOLVED_PATH={result}")
 
+    def test_path_traversal_member_is_safely_flattened(self, tmp_path: Any) -> None:
+        """Path traversal entries must still extract only to the cache binary path."""
+        version = PIXI_VERSION
+        cache = tmp_path / "pyisolate" / "pixi" / version
+
+        fake_binary = b"#!/bin/sh\necho pixi"
+        archive_name = f"pixi{_archive_extension()}"
+        with closing(tempfile.NamedTemporaryFile(suffix=_archive_extension(), delete=False)) as archive_buf:
+            archive_path = Path(archive_buf.name)
+        if platform.system() == "Windows":
+            with zipfile.ZipFile(archive_path, "w") as zf:
+                zf.writestr("../pixi", fake_binary)
+        else:
+            with tarfile.open(archive_path, "w:gz") as tf:
+                info = tarfile.TarInfo(name="../pixi")
+                info.size = len(fake_binary)
+                info.mode = 0o755
+                tf.addfile(info, io.BytesIO(fake_binary))
+
+        archive_data = archive_path.read_bytes()
+        os.unlink(archive_path)
+        archive_hash = hashlib.sha256(archive_data).hexdigest()
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch("pyisolate._internal.pixi_provisioner._cache_dir", return_value=cache),
+            patch("pyisolate._internal.pixi_provisioner._fetch_url") as fetch_mock,
+        ):
+            fetch_mock.side_effect = [
+                f"{archive_hash}  {archive_name}".encode(),
+                archive_data,
+            ]
+            result = ensure_pixi(version)
+            assert Path(result) == cache / _binary_name()
+            assert Path(result).exists()
+            assert not (cache.parent / "pixi").exists()
+
 
 class TestVersionPin:
     def test_version_is_pinned(self) -> None:

--- a/tests/test_remote_handle.py
+++ b/tests/test_remote_handle.py
@@ -9,19 +9,19 @@ from pyisolate._internal.remote_handle import RemoteObjectHandle
 class TestRemoteObjectHandleContract:
     """Tests for RemoteObjectHandle proxy pattern."""
 
-    def test_remote_handle_stores_id(self):
+    def test_remote_handle_stores_id(self) -> None:
         """RemoteObjectHandle stores object ID."""
         handle = RemoteObjectHandle("model_123", "ModelType")
 
         assert handle.object_id == "model_123"
 
-    def test_remote_handle_stores_type_name(self):
+    def test_remote_handle_stores_type_name(self) -> None:
         """RemoteObjectHandle stores type name."""
         handle = RemoteObjectHandle("model_123", "ModelType")
 
         assert handle.type_name == "ModelType"
 
-    def test_remote_handle_repr(self):
+    def test_remote_handle_repr(self) -> None:
         """RemoteObjectHandle has informative repr."""
         handle = RemoteObjectHandle("my_object", "MyClass")
 

--- a/tests/test_rpc_contract.py
+++ b/tests/test_rpc_contract.py
@@ -12,6 +12,7 @@ original_integration/.
 """
 
 import asyncio
+from typing import Any, cast
 
 import pytest
 
@@ -23,14 +24,14 @@ from .fixtures.test_adapter import MockRegistry
 class TestProxiedSingletonContract:
     """Tests for ProxiedSingleton metaclass behavior."""
 
-    def test_singleton_returns_same_instance(self):
+    def test_singleton_returns_same_instance(self) -> None:
         """Multiple instantiations return the same instance."""
         instance1 = MockRegistry()
         instance2 = MockRegistry()
 
         assert instance1 is instance2
 
-    def test_singleton_instance_persists(self):
+    def test_singleton_instance_persists(self) -> None:
         """Singleton instance persists across calls."""
         instance1 = MockRegistry()
         instance1.register("test_object")
@@ -39,11 +40,11 @@ class TestProxiedSingletonContract:
         # Should see the object registered via instance1
         assert instance2.get("obj_0") == "test_object"
 
-    def test_different_singletons_are_independent(self):
+    def test_different_singletons_are_independent(self) -> None:
         """Different ProxiedSingleton subclasses are independent."""
 
         class AnotherRegistry(ProxiedSingleton):
-            def __init__(self):
+            def __init__(self) -> None:
                 super().__init__()
                 self.data = "another"
 
@@ -58,7 +59,7 @@ class TestProxiedSingletonContract:
 class TestRpcMethodContract:
     """Tests for RPC method call contract."""
 
-    def test_method_returns_value(self):
+    def test_method_returns_value(self) -> None:
         """RPC method must return expected value."""
         registry = MockRegistry()
         obj = {"key": "value"}
@@ -68,7 +69,7 @@ class TestRpcMethodContract:
 
         assert result == obj
 
-    def test_method_accepts_arguments(self):
+    def test_method_accepts_arguments(self) -> None:
         """RPC method must accept positional and keyword arguments."""
         registry = MockRegistry()
 
@@ -76,14 +77,14 @@ class TestRpcMethodContract:
         id1 = registry.register("positional_arg")
         assert registry.get(id1) == "positional_arg"
 
-    def test_method_handles_none_return(self):
+    def test_method_handles_none_return(self) -> None:
         """RPC method can return None."""
         registry = MockRegistry()
 
         result = registry.get("nonexistent")
         assert result is None
 
-    def test_method_handles_complex_objects(self):
+    def test_method_handles_complex_objects(self) -> None:
         """RPC method can handle complex nested objects."""
         registry = MockRegistry()
 
@@ -107,7 +108,7 @@ class TestEventLoopResilience:
     recreated (e.g., between workflow executions).
     """
 
-    def test_singleton_survives_loop_recreation(self):
+    def test_singleton_survives_loop_recreation(self) -> None:
         """Singleton instance survives event loop recreation."""
         try:
             previous_loop = asyncio.get_event_loop_policy().get_event_loop()
@@ -135,7 +136,7 @@ class TestEventLoopResilience:
             elif not loop1.is_closed():
                 loop1.close()
 
-    def test_singleton_data_persists_across_loops(self):
+    def test_singleton_data_persists_across_loops(self) -> None:
         """Data stored in singleton persists across event loops."""
         try:
             previous_loop = asyncio.get_event_loop_policy().get_event_loop()
@@ -169,11 +170,11 @@ class TestEventLoopResilience:
 class TestRpcErrorHandling:
     """Tests for RPC error handling contract."""
 
-    def test_method_exception_propagates(self):
+    def test_method_exception_propagates(self) -> None:
         """Exceptions in RPC methods should propagate."""
 
         class FailingService(ProxiedSingleton):
-            def fail(self):
+            def fail(self) -> None:
                 raise ValueError("Intentional failure")
 
         service = FailingService()
@@ -181,7 +182,7 @@ class TestRpcErrorHandling:
         with pytest.raises(ValueError, match="Intentional failure"):
             service.fail()
 
-    def test_type_error_propagates(self):
+    def test_type_error_propagates(self) -> Any:
         """TypeError in RPC methods should propagate."""
 
         class TypedService(ProxiedSingleton):
@@ -192,4 +193,4 @@ class TestRpcErrorHandling:
 
         # Wrong type should raise TypeError
         with pytest.raises(TypeError):
-            service.typed_method("not an int")
+            service.typed_method(cast(Any, "not an int"))

--- a/tests/test_rpc_message_format.py
+++ b/tests/test_rpc_message_format.py
@@ -17,7 +17,7 @@ from pyisolate._internal.rpc_serialization import (
 class TestPrepareForRpc:
     """Tests for _prepare_for_rpc serialization."""
 
-    def test_primitives_pass_through(self):
+    def test_primitives_pass_through(self) -> None:
         """Primitive types pass through unchanged."""
         assert _prepare_for_rpc(42) == 42
         assert _prepare_for_rpc("hello") == "hello"
@@ -25,45 +25,45 @@ class TestPrepareForRpc:
         assert _prepare_for_rpc(True) is True
         assert _prepare_for_rpc(None) is None
 
-    def test_list_preserved(self):
+    def test_list_preserved(self) -> None:
         """Lists are preserved."""
         data = [1, 2, 3]
         result = _prepare_for_rpc(data)
         assert result == [1, 2, 3]
 
-    def test_nested_list(self):
+    def test_nested_list(self) -> None:
         """Nested lists are handled."""
         data = [[1, 2], [3, 4]]
         result = _prepare_for_rpc(data)
         assert result == [[1, 2], [3, 4]]
 
-    def test_dict_preserved(self):
+    def test_dict_preserved(self) -> None:
         """Dicts are preserved."""
         data = {"a": 1, "b": 2}
         result = _prepare_for_rpc(data)
         assert result == {"a": 1, "b": 2}
 
-    def test_nested_dict(self):
+    def test_nested_dict(self) -> None:
         """Nested dicts are handled."""
         data = {"outer": {"inner": 42}}
         result = _prepare_for_rpc(data)
         assert result == {"outer": {"inner": 42}}
 
-    def test_tuple_preserved(self):
+    def test_tuple_preserved(self) -> None:
         """Tuples are preserved (JSON converts to list on transport)."""
         data = (1, 2, 3)
         result = _prepare_for_rpc(data)
         # Implementation preserves tuples; JSON transport converts to list
         assert result == (1, 2, 3) or result == [1, 2, 3]
 
-    def test_attrdict_converted(self):
+    def test_attrdict_converted(self) -> None:
         """AttrDict is converted to plain dict."""
         data = AttrDict({"key": "value"})
         result = _prepare_for_rpc(data)
         assert isinstance(result, dict)
         assert result["key"] == "value"
 
-    def test_attribute_container_handled(self):
+    def test_attribute_container_handled(self) -> None:
         """AttributeContainer is handled appropriately."""
         data = AttributeContainer({"a": 1, "b": 2})
         result = _prepare_for_rpc(data)
@@ -73,7 +73,7 @@ class TestPrepareForRpc:
         else:
             assert hasattr(result, "_data")
 
-    def test_mixed_nested_structure(self):
+    def test_mixed_nested_structure(self) -> None:
         """Mixed nested structures are handled."""
         data = {
             "list": [1, 2, {"nested": True}],
@@ -91,40 +91,40 @@ class TestPrepareForRpc:
 class TestAttrDictBehavior:
     """Tests for AttrDict helper class behavior."""
 
-    def test_attribute_access(self):
+    def test_attribute_access(self) -> None:
         """AttrDict allows attribute-style access."""
         ad = AttrDict({"name": "test", "value": 42})
 
         assert ad.name == "test"
         assert ad.value == 42
 
-    def test_dict_access(self):
+    def test_dict_access(self) -> None:
         """AttrDict allows dict-style access."""
         ad = AttrDict({"name": "test"})
 
         assert ad["name"] == "test"
 
-    def test_nested_dict_access(self):
+    def test_nested_dict_access(self) -> None:
         """Nested dicts accessible via attribute."""
         ad = AttrDict({"outer": {"inner": "value"}})
 
         assert ad.outer["inner"] == "value"
 
-    def test_missing_attribute_raises(self):
+    def test_missing_attribute_raises(self) -> None:
         """Missing attributes raise AttributeError."""
         ad = AttrDict({"existing": True})
 
         with pytest.raises(AttributeError):
             _ = ad.missing
 
-    def test_missing_key_raises(self):
+    def test_missing_key_raises(self) -> None:
         """Missing keys raise KeyError."""
         ad = AttrDict({"existing": True})
 
         with pytest.raises(KeyError):
             _ = ad["missing"]
 
-    def test_iteration(self):
+    def test_iteration(self) -> None:
         """AttrDict can be iterated."""
         ad = AttrDict({"a": 1, "b": 2})
 
@@ -136,21 +136,21 @@ class TestAttrDictBehavior:
 class TestAttributeContainerBehavior:
     """Tests for AttributeContainer helper class behavior."""
 
-    def test_attribute_access(self):
+    def test_attribute_access(self) -> None:
         """AttributeContainer wraps dict with attribute access."""
         container = AttributeContainer({"x": 10, "y": 20})
 
         assert container.x == 10
         assert container.y == 20
 
-    def test_data_property(self):
+    def test_data_property(self) -> None:
         """_data property returns underlying dict."""
         data = {"key": "value"}
         container = AttributeContainer(data)
 
         assert container._data == data
 
-    def test_missing_attribute_raises(self):
+    def test_missing_attribute_raises(self) -> None:
         """Missing attributes raise AttributeError."""
         container = AttributeContainer({"existing": True})
 
@@ -161,11 +161,11 @@ class TestAttributeContainerBehavior:
 class TestSingletonMetaclass:
     """Tests for SingletonMetaclass behavior."""
 
-    def test_singleton_same_instance(self):
+    def test_singleton_same_instance(self) -> None:
         """Multiple instantiations return same instance."""
 
         class MySingleton(ProxiedSingleton):
-            def __init__(self):
+            def __init__(self) -> None:
                 super().__init__()
                 self.value = 42
 
@@ -174,13 +174,13 @@ class TestSingletonMetaclass:
 
         assert a is b
 
-    def test_singleton_state_shared(self):
+    def test_singleton_state_shared(self) -> None:
         """State is shared across references."""
 
         class StatefulSingleton(ProxiedSingleton):
-            def __init__(self):
+            def __init__(self) -> None:
                 super().__init__()
-                self.data = []
+                self.data: list[str] = []
 
         a = StatefulSingleton()
         a.data.append("from_a")
@@ -188,7 +188,7 @@ class TestSingletonMetaclass:
         b = StatefulSingleton()
         assert "from_a" in b.data
 
-    def test_different_singletons_independent(self):
+    def test_different_singletons_independent(self) -> None:
         """Different singleton classes are independent."""
 
         class SingletonA(ProxiedSingleton):

--- a/tests/test_rpc_shutdown.py
+++ b/tests/test_rpc_shutdown.py
@@ -1,6 +1,7 @@
 """Tests for RPC graceful shutdown behavior."""
 
 import asyncio
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -12,17 +13,17 @@ from pyisolate._internal.rpc_transports import RPCTransport
 class MockTransport(RPCTransport):
     """Mock transport that blocks on recv until closed."""
 
-    def __init__(self):
-        self.recv_future = asyncio.Future()
-        self.sent_messages = []
+    def __init__(self) -> None:
+        self.recv_future: asyncio.Future[Any] = asyncio.Future()
+        self.sent_messages: list[Any] = []
         self.closed = False
 
-    def send(self, obj):
+    def send(self, obj: Any) -> None:
         if self.closed:
             raise RuntimeError("Transport closed")
         self.sent_messages.append(obj)
 
-    def recv(self):
+    def recv(self) -> Any:
         """Simulate blocking recv."""
         if self.closed:
             raise ConnectionError("Connection closed")
@@ -30,21 +31,21 @@ class MockTransport(RPCTransport):
         # return a value or raise based on state
         return None  # Returning None signals end of stream in our loop
 
-    def close(self):
+    def close(self) -> None:
         self.closed = True
 
 
 class BlockingMockTransport(RPCTransport):
     """Transport that allows controlling recv blocking."""
 
-    def __init__(self):
-        self.recv_queue = asyncio.Queue()
+    def __init__(self) -> None:
+        self.recv_queue: asyncio.Queue[Any] = asyncio.Queue()
         self.closed = False
 
-    def send(self, obj):
+    def send(self, obj: Any) -> None:
         pass
 
-    def recv(self):
+    def recv(self) -> None:
         # This will be called in a thread
         if self.closed:
             raise ConnectionError("Closed")
@@ -60,12 +61,12 @@ class BlockingMockTransport(RPCTransport):
             time.sleep(0.01)
         raise ConnectionError("Closed during block")
 
-    def close(self):
+    def close(self) -> None:
         self.closed = True
 
 
 @pytest.mark.asyncio
-async def test_shutdown_sets_flag():
+async def test_shutdown_sets_flag() -> None:
     """Test that shutdown() sets the stopping flag."""
     rpc = AsyncRPC(transport=MockTransport())
     assert not rpc._stopping
@@ -74,7 +75,7 @@ async def test_shutdown_sets_flag():
 
 
 @pytest.mark.asyncio
-async def test_shutdown_suppresses_connection_error_logs(caplog):
+async def test_shutdown_suppresses_connection_error_logs(caplog: Any) -> None:
     """Test that connection errors are logged as debug, not error, during shutdown."""
     import logging
 
@@ -87,8 +88,6 @@ async def test_shutdown_suppresses_connection_error_logs(caplog):
     transport = MockTransport()
     # Mock recv to raise an exception immediately then return None (stop loop)
     # Using side_effect with an iterable
-    transport.recv = Mock(side_effect=[ConnectionError("Socket closed"), None])
-
     rpc = AsyncRPC(transport=transport)
     rpc.default_loop = asyncio.get_running_loop()
 
@@ -97,7 +96,9 @@ async def test_shutdown_suppresses_connection_error_logs(caplog):
     assert rpc._stopping is True
 
     # Run _recv_thread synchronously for a single iteration (due to side effect)
-    rpc._recv_thread()
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(transport, "recv", Mock(side_effect=[ConnectionError("Socket closed"), None]))
+        rpc._recv_thread()
 
     # Verify logs
     # We expect a DEBUG log properly formatted, NOT an ERROR log
@@ -114,7 +115,7 @@ async def test_shutdown_suppresses_connection_error_logs(caplog):
 
 
 @pytest.mark.asyncio
-async def test_shutdown_cancels_run_until_stopped():
+async def test_shutdown_cancels_run_until_stopped() -> None:
     """Test that shutdown unblocks run_until_stopped."""
     rpc = AsyncRPC(transport=MockTransport())
 

--- a/tests/test_rpc_shutdown.py
+++ b/tests/test_rpc_shutdown.py
@@ -135,3 +135,29 @@ async def test_shutdown_cancels_run_until_stopped() -> None:
     # Should be done now
     await asyncio.wait_for(stop_task, timeout=1.0)
     assert stop_task.done()
+
+
+@pytest.mark.asyncio
+async def test_recv_none_fails_pending_requests() -> None:
+    """A recv-side sentinel should fail pending requests instead of leaving them dangling."""
+    rpc = AsyncRPC(transport=MockTransport())
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[Any] = loop.create_future()
+    rpc.pending[7] = {
+        "kind": "call",
+        "object_id": "obj",
+        "parent_call_id": None,
+        "calling_loop": loop,
+        "future": future,
+        "method": "ping",
+        "args": (),
+        "kwargs": {},
+    }
+    rpc.blocking_future = loop.create_future()
+
+    rpc._recv_thread()
+    await asyncio.sleep(0)
+
+    assert future.done()
+    with pytest.raises(ConnectionError, match="RPC connection closed"):
+        future.result()

--- a/tests/test_rpc_transports.py
+++ b/tests/test_rpc_transports.py
@@ -5,11 +5,13 @@ headers without allocating multi-GB buffers. Real socketpair() used for
 roundtrip and connection-error tests.
 """
 
+import asyncio
 import contextlib
 import logging
 import socket
 import struct
-from collections.abc import Iterator
+from collections.abc import Callable, Coroutine, Iterator
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -28,7 +30,7 @@ def _make_transport() -> JSONSocketTransport:
     return JSONSocketTransport(a)
 
 
-def _header_then_empty(msg_len: int):  # type: ignore[no-untyped-def]
+def _header_then_empty(msg_len: int) -> Any:  # type: ignore[no-untyped-def]
     """Return a _recvall side_effect: serve header bytes then empty (incomplete body)."""
     header = struct.pack(">I", msg_len & 0xFFFFFFFF)
     call_count = 0
@@ -72,6 +74,43 @@ class TestSendRecvRoundtrip:
         sender, _ = socket_pair
         payload = {"data": "x" * 1000}
         sender.send(payload)  # must not raise
+
+    def test_callable_roundtrip_executes_via_bound_rpc(
+        self, socket_pair: tuple[JSONSocketTransport, JSONSocketTransport]
+    ) -> None:
+        sender, receiver = socket_pair
+
+        class FakeRPC:
+            def __init__(self) -> None:
+                self.callbacks: dict[str, Callable[..., Any]] = {}
+                self.next_id = 0
+
+            def register_callback(self, func: Any) -> Any:  # type: ignore[no-untyped-def]
+                callback_id = f"cb-{self.next_id}"
+                self.next_id += 1
+                self.callbacks[callback_id] = func
+                return callback_id
+
+            async def call_callback(self, callback_id: str, *args: Any, **kwargs: Any) -> Any:  # type: ignore[no-untyped-def]
+                func = self.callbacks[callback_id]
+                result = func(*args, **kwargs)
+                if asyncio.iscoroutine(result):
+                    return await result
+                return result
+
+        sender_rpc = FakeRPC()
+        sender.bind_rpc(sender_rpc)
+        receiver.bind_rpc(sender_rpc)
+
+        def handler(payload: dict[str, int]) -> dict[str, int]:
+            return {"value": payload["value"] + 1}
+
+        sender.send({"handler": handler})
+        result = receiver.recv()
+
+        callback = cast(Callable[[dict[str, int]], Coroutine[Any, Any, dict[str, int]]], result["handler"])
+        callback_result: dict[str, int] = asyncio.run(callback({"value": 41}))
+        assert callback_result == {"value": 42}
 
 
 class TestRecvHardLimit:

--- a/tests/test_sealed_ndarray.py
+++ b/tests/test_sealed_ndarray.py
@@ -1,0 +1,53 @@
+"""Test that SealedNodeExtension registers ndarray as data_type serializer."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pyisolate._internal.serialization_registry import SerializerRegistry
+from pyisolate._internal.singleton_context import singleton_scope
+from pyisolate.sealed import SealedNodeExtension
+
+
+class TestSealedNdarrayTransport:
+    def test_ndarray_registered_as_data_type(self) -> None:
+        """After SealedNodeExtension init, ndarray is a registered data_type."""
+        with singleton_scope():
+            SealedNodeExtension()
+            registry = SerializerRegistry.get_instance()
+            assert registry.has_handler("ndarray")
+            assert registry.is_data_type("ndarray")
+
+    def test_ndarray_serializes_as_tensor_value(self) -> None:
+        """ndarray serializer produces TensorValue dict, not RemoteObjectHandle."""
+        with singleton_scope():
+            SealedNodeExtension()
+            registry = SerializerRegistry.get_instance()
+            serializer = registry.get_serializer("ndarray")
+            assert serializer is not None
+
+            arr = np.random.rand(1, 64, 64, 3).astype(np.float32)
+            result = serializer(arr)
+
+            assert isinstance(result, dict)
+            assert result["__type__"] == "TensorValue"
+            assert result["dtype"] == "torch.float32"
+            assert result["tensor_size"] == [1, 64, 64, 3]
+            assert result["requires_grad"] is False
+            assert isinstance(result["data"], list)
+            print(f"RESULT_TYPE={result['__type__']}")
+
+    def test_wrap_for_transport_passes_ndarray_inline(self) -> None:
+        """_wrap_for_transport does NOT wrap ndarray as RemoteObjectHandle."""
+        with singleton_scope():
+            ext = SealedNodeExtension()
+            arr = np.random.rand(1, 64, 64, 3).astype(np.float32)
+            wrapped = ext._wrap_for_transport(arr)
+
+            # Should NOT be RemoteObjectHandle
+            from pyisolate._internal.remote_handle import RemoteObjectHandle
+
+            assert not isinstance(wrapped, RemoteObjectHandle)
+            # Should still be ndarray (serializer runs at JSON encode time, not at wrap time)
+            assert isinstance(wrapped, np.ndarray)
+            print(f"WRAPPED_TYPE={type(wrapped).__name__}")

--- a/tests/test_sealed_ndarray.py
+++ b/tests/test_sealed_ndarray.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from pyisolate._internal.serialization_registry import SerializerRegistry
 from pyisolate._internal.singleton_context import singleton_scope
@@ -35,7 +36,6 @@ class TestSealedNdarrayTransport:
             assert result["tensor_size"] == [1, 64, 64, 3]
             assert result["requires_grad"] is False
             assert isinstance(result["data"], list)
-            print(f"RESULT_TYPE={result['__type__']}")
 
     def test_wrap_for_transport_passes_ndarray_inline(self) -> None:
         """_wrap_for_transport does NOT wrap ndarray as RemoteObjectHandle."""
@@ -50,4 +50,15 @@ class TestSealedNdarrayTransport:
             assert not isinstance(wrapped, RemoteObjectHandle)
             # Should still be ndarray (serializer runs at JSON encode time, not at wrap time)
             assert isinstance(wrapped, np.ndarray)
-            print(f"WRAPPED_TYPE={type(wrapped).__name__}")
+
+    def test_unsupported_ndarray_dtype_raises(self) -> None:
+        """Unsupported ndarray dtypes fail fast instead of silently downcasting."""
+        with singleton_scope():
+            SealedNodeExtension()
+            registry = SerializerRegistry.get_instance()
+            serializer = registry.get_serializer("ndarray")
+            assert serializer is not None
+
+            arr = np.array(["x", "y"], dtype=np.str_)
+            with pytest.raises(TypeError, match="Unsupported ndarray dtype"):
+                serializer(arr)

--- a/tests/test_sealed_proxy_handle.py
+++ b/tests/test_sealed_proxy_handle.py
@@ -14,7 +14,7 @@ from pyisolate.sealed import SealedNodeExtension
 
 
 @pytest.fixture(autouse=True)
-def clean_registry():
+def clean_registry() -> None:
     SerializerRegistry.get_instance().clear()
 
 
@@ -25,7 +25,7 @@ class _FakeWidget:
         self.value = value
 
 
-def test_sealed_wraps_unregistered_object_as_handle():
+def test_sealed_wraps_unregistered_object_as_handle() -> None:
     ext = SealedNodeExtension()
     widget = _FakeWidget(42)
 
@@ -37,7 +37,7 @@ def test_sealed_wraps_unregistered_object_as_handle():
     assert ext.remote_objects[result.object_id] is widget
 
 
-def test_sealed_resolves_handle_to_original_object():
+def test_sealed_resolves_handle_to_original_object() -> None:
     ext = SealedNodeExtension()
     original = _FakeWidget(99)
     ext.remote_objects["id-1"] = original
@@ -48,7 +48,7 @@ def test_sealed_resolves_handle_to_original_object():
     assert result is original
 
 
-def test_sealed_stale_handle_raises_keyerror():
+def test_sealed_stale_handle_raises_keyerror() -> None:
     ext = SealedNodeExtension()
 
     handle = RemoteObjectHandle("nonexistent", "Foo")
@@ -56,16 +56,15 @@ def test_sealed_stale_handle_raises_keyerror():
         ext._resolve_handles(handle)
 
 
-def test_sealed_ndarray_roundtrip_via_handle():
+def test_sealed_ndarray_roundtrip_via_handle() -> None:
     ext = SealedNodeExtension()
     original = np.ones((100, 100), dtype=np.float32)
 
-    # Wrap — ndarray has no registered serializer so it becomes a handle
+    # ndarray is a registered data_type serializer, so it stays inline.
     wrapped = ext._wrap_for_transport(original)
-    assert isinstance(wrapped, RemoteObjectHandle)
-    assert wrapped.type_name == "ndarray"
+    assert isinstance(wrapped, np.ndarray)
 
-    # Resolve — should return the exact same object
+    # Inline data passes through unchanged.
     resolved = ext._resolve_handles(wrapped)
     assert resolved is original
     assert np.array_equal(original, resolved)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -8,7 +8,7 @@ from pyisolate._internal.host import normalize_extension_name, validate_dependen
 class TestSecurityValidation:
     """Test security validation functions."""
 
-    def test_normalize_extension_name_basic(self):
+    def test_normalize_extension_name_basic(self) -> None:
         """Test basic extension name normalization."""
         test_cases = [
             # (input, expected_output)
@@ -22,7 +22,7 @@ class TestSecurityValidation:
         for input_name, expected in test_cases:
             assert normalize_extension_name(input_name) == expected
 
-    def test_normalize_extension_name_with_spaces(self):
+    def test_normalize_extension_name_with_spaces(self) -> None:
         """Test that spaces are replaced with underscores."""
         test_cases = [
             ("my extension", "my_extension"),
@@ -36,7 +36,7 @@ class TestSecurityValidation:
         for input_name, expected in test_cases:
             assert normalize_extension_name(input_name) == expected
 
-    def test_normalize_extension_name_unicode(self):
+    def test_normalize_extension_name_unicode(self) -> None:
         """Test that Unicode characters are preserved."""
         test_cases = [
             ("扩展名", "扩展名"),  # Chinese
@@ -48,7 +48,7 @@ class TestSecurityValidation:
         for input_name, expected in test_cases:
             assert normalize_extension_name(input_name) == expected
 
-    def test_normalize_extension_name_dangerous_chars(self):
+    def test_normalize_extension_name_dangerous_chars(self) -> None:
         """Test that dangerous characters are replaced."""
         test_cases = [
             ("ext|pipe", "ext_pipe"),
@@ -71,7 +71,7 @@ class TestSecurityValidation:
         for input_name, expected in test_cases:
             assert normalize_extension_name(input_name) == expected
 
-    def test_normalize_extension_name_path_traversal(self):
+    def test_normalize_extension_name_path_traversal(self) -> None:
         """Test that path traversal attempts are neutralized."""
         test_cases = [
             ("../evil", "evil"),  # Dots at start removed
@@ -84,7 +84,7 @@ class TestSecurityValidation:
         for input_name, expected in test_cases:
             assert normalize_extension_name(input_name) == expected
 
-    def test_normalize_extension_name_edge_cases(self):
+    def test_normalize_extension_name_edge_cases(self) -> None:
         """Test edge cases in normalization."""
         # Empty name should raise
         with pytest.raises(ValueError, match="Extension name cannot be empty"):
@@ -101,7 +101,7 @@ class TestSecurityValidation:
         with pytest.raises(ValueError, match="contains only invalid characters"):
             normalize_extension_name("....")
 
-    def test_validate_dependency_valid(self):
+    def test_validate_dependency_valid(self) -> None:
         """Test that valid dependencies pass validation."""
         valid_deps = [
             "numpy",
@@ -117,7 +117,7 @@ class TestSecurityValidation:
         for dep in valid_deps:
             validate_dependency(dep)  # Should not raise
 
-    def test_validate_dependency_invalid(self):
+    def test_validate_dependency_invalid(self) -> None:
         """Test that invalid dependencies are rejected."""
         invalid_cases = [
             ("--extra-index-url", "cannot start with '-'"),
@@ -137,7 +137,7 @@ class TestSecurityValidation:
             with pytest.raises(ValueError, match=expected_msg):
                 validate_dependency(dep)
 
-    def test_dependency_injection_attempts(self):
+    def test_dependency_injection_attempts(self) -> None:
         """Test various dependency injection attempts are blocked."""
         # Test that we can't inject extra index URLs
         with pytest.raises(ValueError):

--- a/tests/test_security_conda.py
+++ b/tests/test_security_conda.py
@@ -6,26 +6,31 @@ import contextlib
 import os
 import re
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from pyisolate._internal.sandbox_detect import RestrictionModel
+from pyisolate.config import ExtensionConfig
 
 
-def _make_extension():
+def _make_extension() -> Any:
     from pyisolate._internal.host import Extension
     from pyisolate.shared import ExtensionBase
 
-    config = {
-        "name": "test_conda",
-        "module": "test_module",
-        "dependencies": [],
-        "share_torch": False,
-        "share_cuda_ipc": False,
-        "package_manager": "conda",
-        "execution_model": "sealed_worker",
-        "conda_channels": ["conda-forge"],
-        "conda_dependencies": ["numpy"],
-    }
+    config = cast(
+        ExtensionConfig,
+        {
+            "name": "test_conda",
+            "module": "test_module",
+            "dependencies": [],
+            "share_torch": False,
+            "share_cuda_ipc": False,
+            "package_manager": "conda",
+            "execution_model": "sealed_worker",
+            "conda_channels": ["conda-forge"],
+            "conda_dependencies": ["numpy"],
+        },
+    )
 
     ext = Extension.__new__(Extension)
     ext.name = "test_conda"
@@ -46,7 +51,7 @@ def _pixi_python_path() -> Path:
     return Path("/fake/venv/.pixi/envs/default/bin/python")
 
 
-def _launch_extension(ext, mock_popen: MagicMock) -> MagicMock:
+def _launch_extension(ext: Any, mock_popen: MagicMock) -> MagicMock:
     mock_proc = MagicMock()
     mock_proc.pid = 12345
     mock_proc.args = [

--- a/tests/test_security_sealed_worker.py
+++ b/tests/test_security_sealed_worker.py
@@ -5,24 +5,29 @@ from __future__ import annotations
 import contextlib
 import re
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from pyisolate._internal.sandbox_detect import RestrictionModel
+from pyisolate.config import ExtensionConfig
 
 
-def _make_extension():
+def _make_extension() -> Any:
     from pyisolate._internal.host import Extension
     from pyisolate.shared import ExtensionBase
 
-    config = {
-        "name": "test_sealed",
-        "module": "test_module",
-        "dependencies": [],
-        "share_torch": False,
-        "share_cuda_ipc": False,
-        "package_manager": "uv",
-        "execution_model": "sealed_worker",
-    }
+    config = cast(
+        ExtensionConfig,
+        {
+            "name": "test_sealed",
+            "module": "test_module",
+            "dependencies": [],
+            "share_torch": False,
+            "share_cuda_ipc": False,
+            "package_manager": "uv",
+            "execution_model": "sealed_worker",
+        },
+    )
 
     ext = Extension.__new__(Extension)
     ext.name = "test_sealed"
@@ -37,7 +42,7 @@ def _make_extension():
     return ext
 
 
-def _launch_extension(ext, mock_popen: MagicMock) -> MagicMock:
+def _launch_extension(ext: Any, mock_popen: MagicMock) -> MagicMock:
     mock_proc = MagicMock()
     mock_proc.pid = 12345
     mock_popen.return_value = mock_proc

--- a/tests/test_serialization_contract.py
+++ b/tests/test_serialization_contract.py
@@ -11,6 +11,7 @@ They use the MockHostAdapter's serializers as the reference implementation.
 """
 
 import json
+from typing import Any
 
 from pyisolate._internal.serialization_registry import SerializerRegistry
 
@@ -20,39 +21,39 @@ from .fixtures.test_adapter import MockHostAdapter, MockTestData
 class TestSerializerRegistryContract:
     """Tests for SerializerRegistry protocol compliance."""
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         """Get fresh registry for each test."""
         self.registry = SerializerRegistry.get_instance()
         self.registry.clear()
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         """Clear registry after each test."""
         self.registry.clear()
 
-    def test_registry_is_singleton(self):
+    def test_registry_is_singleton(self) -> None:
         """SerializerRegistry.get_instance() returns same instance."""
         reg1 = SerializerRegistry.get_instance()
         reg2 = SerializerRegistry.get_instance()
 
         assert reg1 is reg2
 
-    def test_register_serializer(self):
+    def test_register_serializer(self) -> Any:
         """Can register a serializer for a type."""
 
-        def serialize(obj):
+        def serialize(obj: Any) -> Any:
             return {"value": obj}
 
         self.registry.register("MyType", serialize)
 
         assert self.registry.has_handler("MyType")
 
-    def test_register_with_deserializer(self):
+    def test_register_with_deserializer(self) -> Any:
         """Can register both serializer and deserializer."""
 
-        def serialize(obj):
+        def serialize(obj: Any) -> Any:
             return {"v": obj}
 
-        def deserialize(data):
+        def deserialize(data: Any) -> Any:
             return data["v"]
 
         self.registry.register("MyType", serialize, deserialize)
@@ -60,10 +61,10 @@ class TestSerializerRegistryContract:
         assert self.registry.get_serializer("MyType") is not None
         assert self.registry.get_deserializer("MyType") is not None
 
-    def test_get_serializer_returns_callable(self):
+    def test_get_serializer_returns_callable(self) -> Any:
         """get_serializer returns the registered callable."""
 
-        def my_serializer(obj):
+        def my_serializer(obj: Any) -> Any:
             return str(obj)
 
         self.registry.register("StringType", my_serializer)
@@ -71,10 +72,10 @@ class TestSerializerRegistryContract:
         retrieved = self.registry.get_serializer("StringType")
         assert retrieved is my_serializer
 
-    def test_get_deserializer_returns_callable(self):
+    def test_get_deserializer_returns_callable(self) -> Any:
         """get_deserializer returns the registered callable."""
 
-        def my_deserializer(data):
+        def my_deserializer(data: Any) -> Any:
             return int(data)
 
         self.registry.register("IntType", lambda x: x, my_deserializer)
@@ -82,16 +83,16 @@ class TestSerializerRegistryContract:
         retrieved = self.registry.get_deserializer("IntType")
         assert retrieved is my_deserializer
 
-    def test_get_unregistered_returns_none(self):
+    def test_get_unregistered_returns_none(self) -> None:
         """get_serializer/get_deserializer return None for unknown types."""
         assert self.registry.get_serializer("UnknownType") is None
         assert self.registry.get_deserializer("UnknownType") is None
 
-    def test_has_handler_false_for_unknown(self):
+    def test_has_handler_false_for_unknown(self) -> None:
         """has_handler returns False for unregistered types."""
         assert self.registry.has_handler("UnknownType") is False
 
-    def test_has_handler_true_for_registered(self):
+    def test_has_handler_true_for_registered(self) -> None:
         """has_handler returns True for registered types."""
         self.registry.register("KnownType", lambda x: x)
 
@@ -101,7 +102,7 @@ class TestSerializerRegistryContract:
 class TestSerializationRoundtrip:
     """Tests for serialization roundtrip correctness."""
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         """Set up registry with MockHostAdapter serializers."""
         self.registry = SerializerRegistry.get_instance()
         self.registry.clear()
@@ -109,52 +110,60 @@ class TestSerializationRoundtrip:
         adapter = MockHostAdapter()
         adapter.register_serializers(self.registry)
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         """Clear registry after each test."""
         self.registry.clear()
 
-    def test_testdata_roundtrip(self):
+    def test_testdata_roundtrip(self) -> None:
         """TestData survives serialization roundtrip."""
         original = MockTestData("hello world")
 
         serializer = self.registry.get_serializer("MockTestData")
         deserializer = self.registry.get_deserializer("MockTestData")
+        assert serializer is not None
+        assert deserializer is not None
 
         serialized = serializer(original)
         deserialized = deserializer(serialized)
 
         assert deserialized == original
 
-    def test_testdata_with_int_value(self):
+    def test_testdata_with_int_value(self) -> None:
         """TestData with int value roundtrips correctly."""
         original = MockTestData(42)
 
         serializer = self.registry.get_serializer("MockTestData")
         deserializer = self.registry.get_deserializer("MockTestData")
+        assert serializer is not None
+        assert deserializer is not None
 
         serialized = serializer(original)
         deserialized = deserializer(serialized)
 
         assert deserialized.value == 42
 
-    def test_testdata_with_list_value(self):
+    def test_testdata_with_list_value(self) -> None:
         """TestData with list value roundtrips correctly."""
         original = MockTestData([1, 2, 3])
 
         serializer = self.registry.get_serializer("MockTestData")
         deserializer = self.registry.get_deserializer("MockTestData")
+        assert serializer is not None
+        assert deserializer is not None
 
         serialized = serializer(original)
         deserialized = deserializer(serialized)
 
         assert deserialized.value == [1, 2, 3]
 
-    def test_testdata_with_dict_value(self):
+    def test_testdata_with_dict_value(self) -> None:
         """TestData with dict value roundtrips correctly."""
         original = MockTestData({"key": "value", "nested": {"a": 1}})
 
         serializer = self.registry.get_serializer("MockTestData")
         deserializer = self.registry.get_deserializer("MockTestData")
+        assert serializer is not None
+        assert deserializer is not None
 
         serialized = serializer(original)
         deserialized = deserializer(serialized)
@@ -165,7 +174,7 @@ class TestSerializationRoundtrip:
 class TestJsonCompatibility:
     """Tests that serialized output is JSON-compatible."""
 
-    def setup_method(self):
+    def setup_method(self) -> None:
         """Set up registry with MockHostAdapter serializers."""
         self.registry = SerializerRegistry.get_instance()
         self.registry.clear()
@@ -173,27 +182,30 @@ class TestJsonCompatibility:
         adapter = MockHostAdapter()
         adapter.register_serializers(self.registry)
 
-    def teardown_method(self):
+    def teardown_method(self) -> None:
         """Clear registry after each test."""
         self.registry.clear()
 
-    def test_serialized_is_json_serializable(self):
+    def test_serialized_is_json_serializable(self) -> None:
         """Serialized output must be JSON-serializable."""
         original = MockTestData("test")
 
         serializer = self.registry.get_serializer("MockTestData")
+        assert serializer is not None
         serialized = serializer(original)
 
         # Must not raise
         json_str = json.dumps(serialized)
         assert json_str
 
-    def test_json_roundtrip_preserves_data(self):
+    def test_json_roundtrip_preserves_data(self) -> None:
         """Data survives JSON serialization between processes."""
         original = MockTestData({"complex": [1, 2, {"nested": True}]})
 
         serializer = self.registry.get_serializer("MockTestData")
         deserializer = self.registry.get_deserializer("MockTestData")
+        assert serializer is not None
+        assert deserializer is not None
 
         # Simulate cross-process: serialize -> JSON -> deserialize
         serialized = serializer(original)
@@ -207,7 +219,7 @@ class TestJsonCompatibility:
 class TestSerializerProtocolCompliance:
     """Tests for SerializerRegistryProtocol compliance."""
 
-    def test_registry_matches_protocol(self):
+    def test_registry_matches_protocol(self) -> None:
         """SerializerRegistry implements SerializerRegistryProtocol."""
 
         registry = SerializerRegistry.get_instance()
@@ -224,7 +236,7 @@ class TestSerializerProtocolCompliance:
         assert callable(registry.get_deserializer)
         assert callable(registry.has_handler)
 
-    def test_register_signature(self):
+    def test_register_signature(self) -> None:
         """register() accepts type_name, serializer, and optional deserializer."""
         registry = SerializerRegistry.get_instance()
         registry.clear()

--- a/tests/test_shared_additional.py
+++ b/tests/test_shared_additional.py
@@ -1,6 +1,7 @@
 import asyncio
 import queue
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -19,7 +20,7 @@ from pyisolate._internal.rpc_serialization import (
 )
 
 
-def test_prepare_for_rpc_nested_attr_container(monkeypatch):
+def test_prepare_for_rpc_nested_attr_container(monkeypatch: Any) -> None:
     payload = {
         "attr": AttributeContainer({"a": 1, "b": AttrDict({"c": 2})}),
         "list": [AttrDict({"d": 3})],
@@ -29,7 +30,7 @@ def test_prepare_for_rpc_nested_attr_container(monkeypatch):
     assert "attr" in converted and "list" in converted
 
 
-def test_tensor_to_cuda_attribute_container():
+def test_tensor_to_cuda_attribute_container() -> None:
     obj = {
         "__pyisolate_attribute_container__": True,
         "data": {"x": {"__pyisolate_attrdict__": True, "data": {"z": 5}}},
@@ -41,7 +42,7 @@ def test_tensor_to_cuda_attribute_container():
 
 
 @pytest.mark.asyncio
-async def test_async_rpc_stop_requires_run():
+async def test_async_rpc_stop_requires_run() -> None:
     import multiprocessing
 
     recv_q = multiprocessing.get_context("spawn").Queue()
@@ -49,10 +50,11 @@ async def test_async_rpc_stop_requires_run():
     rpc = AsyncRPC(recv_queue=recv_q, send_queue=send_q)
     rpc.run()
     await rpc.stop()
+    assert rpc.blocking_future is not None
     assert rpc.blocking_future.done() is True
 
 
-def test_async_rpc_send_thread_sets_exception_on_send_failure():
+def test_async_rpc_send_thread_sets_exception_on_send_failure() -> None:
     previous_loop = None
     loop = asyncio.new_event_loop()
     try:
@@ -62,11 +64,11 @@ def test_async_rpc_send_thread_sets_exception_on_send_failure():
     asyncio.set_event_loop(loop)
 
     class FailingQueue:
-        def put(self, _):
+        def put(self, _: Any) -> None:
             raise RuntimeError("boom")
 
-    recv_q: queue.Queue = queue.Queue()
-    rpc = AsyncRPC(recv_queue=recv_q, send_queue=FailingQueue())
+    recv_q: Any = queue.Queue()
+    rpc = AsyncRPC(recv_queue=cast(Any, recv_q), send_queue=cast(Any, FailingQueue()))
 
     pending = RPCPendingRequest(  # type: ignore[call-arg]
         kind="call",
@@ -92,7 +94,7 @@ def test_async_rpc_send_thread_sets_exception_on_send_failure():
         loop.close()
 
 
-def test_async_rpc_send_thread_callback_failure_sets_exception():
+def test_async_rpc_send_thread_callback_failure_sets_exception() -> None:
     previous_loop = None
     loop = asyncio.new_event_loop()
     try:
@@ -102,11 +104,11 @@ def test_async_rpc_send_thread_callback_failure_sets_exception():
     asyncio.set_event_loop(loop)
 
     class FailingQueue:
-        def put(self, _):
+        def put(self, _: Any) -> None:
             raise RuntimeError("kaboom")
 
-    recv_q: queue.Queue = queue.Queue()
-    rpc = AsyncRPC(recv_queue=recv_q, send_queue=FailingQueue())
+    recv_q: Any = queue.Queue()
+    rpc = AsyncRPC(recv_queue=cast(Any, recv_q), send_queue=cast(Any, FailingQueue()))
 
     pending = RPCPendingRequest(  # type: ignore[call-arg]
         kind="callback",
@@ -132,7 +134,7 @@ def test_async_rpc_send_thread_callback_failure_sets_exception():
         loop.close()
 
 
-def test_singleton_metaclass_inject_guard():
+def test_singleton_metaclass_inject_guard() -> None:
     class Demo(metaclass=SingletonMetaclass):
         pass
 
@@ -141,7 +143,7 @@ def test_singleton_metaclass_inject_guard():
         Demo.inject_instance(object())
 
 
-def test_proxied_singleton_registers_nested(monkeypatch):
+def test_proxied_singleton_registers_nested(monkeypatch: Any) -> None:
     class Nested(ProxiedSingleton):
         pass
 
@@ -149,6 +151,6 @@ def test_proxied_singleton_registers_nested(monkeypatch):
         child = Nested()
 
     rpc = SimpleNamespace(register_callee=MagicMock())
-    Parent()._register(rpc)  # instance register should register child but not self twice
+    Parent()._register(cast(Any, rpc))  # instance register should register child but not self twice
     assert rpc.register_callee.call_count == 2
     # Note: Singleton cleanup handled by conftest autouse fixture

--- a/tests/test_singleton_lifecycle.py
+++ b/tests/test_singleton_lifecycle.py
@@ -176,7 +176,7 @@ class TestSingletonScopeIsolation:
 class TestUseRemoteInjection:
     """Tests for use_remote() proxy injection."""
 
-    def test_use_remote_injects_proxy(self) -> Any:
+    def test_use_remote_injects_proxy(self) -> None:
         """Verify use_remote() injects caller as singleton instance."""
 
         class RemoteService(ProxiedSingleton):
@@ -201,7 +201,7 @@ class TestUseRemoteInjection:
         assert instance.cls is RemoteService
         assert instance.object_id == "RemoteService"
 
-    def test_use_remote_requires_proxied_singleton(self) -> Any:
+    def test_use_remote_requires_proxied_singleton(self) -> None:
         """Verify use_remote() only works with ProxiedSingleton subclasses."""
 
         class NotProxied(metaclass=SingletonMetaclass):
@@ -220,7 +220,7 @@ class TestUseRemoteInjection:
 class TestNestedSingletonRegistration:
     """Tests for nested ProxiedSingleton registration."""
 
-    def test_nested_singleton_attributes_get_proxies(self) -> Any:
+    def test_nested_singleton_attributes_get_proxies(self) -> None:
         """Verify type-hinted singleton attributes receive caller proxies."""
 
         class ChildService(ProxiedSingleton):

--- a/tests/test_singleton_lifecycle.py
+++ b/tests/test_singleton_lifecycle.py
@@ -4,6 +4,8 @@ These tests explicitly verify singleton injection/cleanup lifecycle behavior,
 particularly the singleton_scope context manager and use_remote() injection.
 """
 
+from typing import Any, cast
+
 import pytest
 
 from pyisolate._internal.rpc_protocol import (
@@ -25,11 +27,11 @@ class TestSingletonScopeIsolation:
     are undone when the scope exits.
     """
 
-    def test_scope_restores_state_on_exit(self):
+    def test_scope_restores_state_on_exit(self) -> None:
         """Verify singleton_scope restores previous state on exit."""
 
         class RestoreService(ProxiedSingleton):
-            def __init__(self):
+            def __init__(self) -> None:
                 super().__init__()
                 self.value = "original"
 
@@ -53,7 +55,7 @@ class TestSingletonScopeIsolation:
         assert after is before
         assert after.value == "modified"
 
-    def test_scope_removes_new_singletons_on_exit(self):
+    def test_scope_removes_new_singletons_on_exit(self) -> None:
         """Verify singletons created in scope are removed on exit."""
 
         class NewService(ProxiedSingleton):
@@ -70,7 +72,7 @@ class TestSingletonScopeIsolation:
         # After scope, NewService is removed (restored to pre-scope state)
         assert NewService not in SingletonMetaclass._instances
 
-    def test_nested_scopes_restore_registry_correctly(self):
+    def test_nested_scopes_restore_registry_correctly(self) -> None:
         """Verify nested singleton_scope contexts restore registry correctly.
 
         Note: singleton_scope restores REGISTRY state (which instances exist),
@@ -111,7 +113,7 @@ class TestSingletonScopeIsolation:
         # OuterService still exists
         assert OuterService in SingletonMetaclass._instances
 
-    def test_scope_cleanup_on_exception(self):
+    def test_scope_cleanup_on_exception(self) -> None:
         """Verify singleton_scope cleans up registry even on exception."""
 
         class BeforeService(ProxiedSingleton):
@@ -142,7 +144,7 @@ class TestSingletonScopeIsolation:
         # InsideService should be removed
         assert InsideService not in SingletonMetaclass._instances
 
-    def test_scope_isolates_new_registrations(self):
+    def test_scope_isolates_new_registrations(self) -> None:
         """Verify new singletons created in scope don't leak out."""
 
         class ScopedServiceA(ProxiedSingleton):
@@ -174,24 +176,24 @@ class TestSingletonScopeIsolation:
 class TestUseRemoteInjection:
     """Tests for use_remote() proxy injection."""
 
-    def test_use_remote_injects_proxy(self):
+    def test_use_remote_injects_proxy(self) -> Any:
         """Verify use_remote() injects caller as singleton instance."""
 
         class RemoteService(ProxiedSingleton):
-            async def remote_method(self):
+            async def remote_method(self) -> Any:
                 return "remote"
 
         class FakeRPC:
-            def __init__(self):
-                self.callers = []
+            def __init__(self) -> None:
+                self.callers: list[Any] = []
 
-            def create_caller(self, cls, object_id):
+            def create_caller(self, cls: Any, object_id: Any) -> Any:
                 caller = type("FakeCaller", (), {"cls": cls, "object_id": object_id})()
                 self.callers.append(caller)
                 return caller
 
         rpc = FakeRPC()
-        RemoteService.use_remote(rpc)
+        RemoteService.use_remote(cast(Any, rpc))
 
         # Instance should be the injected proxy
         instance = RemoteService()
@@ -199,49 +201,49 @@ class TestUseRemoteInjection:
         assert instance.cls is RemoteService
         assert instance.object_id == "RemoteService"
 
-    def test_use_remote_requires_proxied_singleton(self):
+    def test_use_remote_requires_proxied_singleton(self) -> Any:
         """Verify use_remote() only works with ProxiedSingleton subclasses."""
 
         class NotProxied(metaclass=SingletonMetaclass):
             pass
 
         class FakeRPC:
-            def create_caller(self, cls, object_id):
+            def create_caller(self, cls: Any, object_id: Any) -> Any:
                 return object()
 
         rpc = FakeRPC()
 
         with pytest.raises(AssertionError, match="must inherit from ProxiedSingleton"):
-            NotProxied.use_remote(rpc)
+            NotProxied.use_remote(cast(Any, rpc))
 
 
 class TestNestedSingletonRegistration:
     """Tests for nested ProxiedSingleton registration."""
 
-    def test_nested_singleton_attributes_get_proxies(self):
+    def test_nested_singleton_attributes_get_proxies(self) -> Any:
         """Verify type-hinted singleton attributes receive caller proxies."""
 
         class ChildService(ProxiedSingleton):
-            async def child_method(self):
+            async def child_method(self) -> Any:
                 return "child"
 
         class ParentService(ProxiedSingleton):
             child: ChildService  # Type-hinted attribute
 
-            async def parent_method(self):
+            async def parent_method(self) -> Any:
                 return "parent"
 
         class FakeRPC:
-            def __init__(self):
-                self.callers = {}
+            def __init__(self) -> None:
+                self.callers: dict[str, Any] = {}
 
-            def create_caller(self, cls, object_id):
+            def create_caller(self, cls: Any, object_id: Any) -> Any:
                 caller = type("FakeCaller", (), {"cls": cls, "object_id": object_id})()
                 self.callers[object_id] = caller
                 return caller
 
         rpc = FakeRPC()
-        ParentService.use_remote(rpc)
+        ParentService.use_remote(cast(Any, rpc))
 
         # Both parent and child should have callers
         assert "ParentService" in rpc.callers
@@ -252,7 +254,7 @@ class TestNestedSingletonRegistration:
         assert hasattr(parent, "child")
         assert parent.child is rpc.callers["ChildService"]
 
-    def test_register_callee_for_nested_singletons(self):
+    def test_register_callee_for_nested_singletons(self) -> None:
         """Verify _register() recursively registers nested singletons."""
 
         class InnerService(ProxiedSingleton):
@@ -261,15 +263,15 @@ class TestNestedSingletonRegistration:
         class OuterService(ProxiedSingleton):
             inner = InnerService()
 
-        registered = []
+        registered: list[tuple[Any, Any]] = []
 
         class FakeRPC:
-            def register_callee(self, obj, object_id):
+            def register_callee(self, obj: Any, object_id: Any) -> None:
                 registered.append((obj, object_id))
 
         rpc = FakeRPC()
         outer = OuterService()
-        outer._register(rpc)
+        outer._register(cast(Any, rpc))
 
         # Both outer and inner should be registered
         object_ids = [obj_id for _, obj_id in registered]
@@ -280,7 +282,7 @@ class TestNestedSingletonRegistration:
 class TestSingletonEdgeCases:
     """Tests for edge cases in singleton lifecycle."""
 
-    def test_inject_before_instantiation(self):
+    def test_inject_before_instantiation(self) -> None:
         """Verify inject_instance() must be called before instantiation."""
 
         class LateInjection(ProxiedSingleton):
@@ -293,11 +295,11 @@ class TestSingletonEdgeCases:
         with pytest.raises(AssertionError, match="singleton already exists"):
             SingletonMetaclass.inject_instance(LateInjection, object())
 
-    def test_get_instance_creates_if_missing(self):
+    def test_get_instance_creates_if_missing(self) -> None:
         """Verify get_instance() creates instance if not exists."""
 
         class LazyService(ProxiedSingleton):
-            def __init__(self):
+            def __init__(self) -> None:
                 super().__init__()
                 self.initialized = True
 
@@ -312,7 +314,7 @@ class TestSingletonEdgeCases:
         # Should return same instance
         assert LazyService.get_instance() is instance
 
-    def test_get_remote_id_uses_class_name(self):
+    def test_get_remote_id_uses_class_name(self) -> None:
         """Verify get_remote_id() returns class name by default."""
 
         class CustomNameService(ProxiedSingleton):
@@ -320,12 +322,12 @@ class TestSingletonEdgeCases:
 
         assert CustomNameService.get_remote_id() == "CustomNameService"
 
-    def test_custom_get_remote_id(self):
+    def test_custom_get_remote_id(self) -> Any:
         """Verify get_remote_id() can be overridden."""
 
         class CustomIdService(ProxiedSingleton):
             @classmethod
-            def get_remote_id(cls):
+            def get_remote_id(cls) -> Any:
                 return "custom_service_id"
 
         assert CustomIdService.get_remote_id() == "custom_service_id"

--- a/tests/test_singleton_shared.py
+++ b/tests/test_singleton_shared.py
@@ -1,5 +1,8 @@
 """Unit tests for SingletonMetaclass and ProxiedSingleton behavior."""
 
+from collections.abc import Generator
+from typing import Any, cast
+
 import pytest
 
 from pyisolate._internal.rpc_protocol import (
@@ -11,7 +14,7 @@ from pyisolate._internal.rpc_protocol import (
 
 
 @pytest.fixture(autouse=True)
-def reset_singleton_state():
+def reset_singleton_state() -> Generator[None, None, None]:
     """Ensure singleton/global registries are clean for every test.
 
     Note: This fixture explicitly resets LocalMethodRegistry in addition to
@@ -26,67 +29,68 @@ def reset_singleton_state():
 class FakeCaller:
     """Minimal callable returned by FakeRPC.create_caller."""
 
-    def __init__(self, target_cls, object_id):
+    def __init__(self, target_cls: Any, object_id: Any) -> None:
         self.target_cls = target_cls
         self.object_id = object_id
+        self.child: Any = None
 
 
 class FakeRPC:
     """Capture create_caller invocations without spinning up real RPC."""
 
-    def __init__(self):
-        self.calls = []
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, Any, FakeCaller]] = []
 
-    def create_caller(self, cls, object_id):
+    def create_caller(self, cls: Any, object_id: Any) -> Any:
         caller = FakeCaller(cls, object_id)
         self.calls.append((cls, object_id, caller))
         return caller
 
 
 class BasicSingleton(ProxiedSingleton):
-    async def ping(self):  # pragma: no cover - method invoked via proxy
+    async def ping(self) -> Any:  # pragma: no cover - method invoked via proxy
         return "pong"
 
 
 class LocalMethodSingleton(ProxiedSingleton):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.counter = 0
 
     @local_execution
-    def increment(self):
+    def increment(self) -> Any:
         self.counter += 1
         return self.counter
 
 
 class ChildSingleton(ProxiedSingleton):
-    async def child_call(self):  # pragma: no cover
+    async def child_call(self) -> Any:  # pragma: no cover
         return "child"
 
 
 class ParentSingleton(ProxiedSingleton):
     child: ChildSingleton
 
-    async def parent_call(self):  # pragma: no cover
+    async def parent_call(self) -> Any:  # pragma: no cover
         return "parent"
 
 
 class TestSingletonMetaclass:
-    def test_inject_instance_after_instantiation_raises(self):
+    def test_inject_instance_after_instantiation_raises(self) -> None:
         """inject_instance must run before first instantiation."""
         BasicSingleton()
         with pytest.raises(AssertionError):
             SingletonMetaclass.inject_instance(BasicSingleton, object())
 
-    def test_get_remote_id_defaults_to_class_name(self):
+    def test_get_remote_id_defaults_to_class_name(self) -> None:
         assert BasicSingleton.get_remote_id() == "BasicSingleton"
 
 
 class TestUseRemote:
-    def test_use_remote_sets_proxy_instance(self):
+    def test_use_remote_sets_proxy_instance(self) -> None:
         """use_remote should inject proxy returned by RPC."""
         rpc = FakeRPC()
-        BasicSingleton.use_remote(rpc)
+        BasicSingleton.use_remote(cast(Any, rpc))
 
         assert BasicSingleton in SingletonMetaclass._instances
         proxy = SingletonMetaclass._instances[BasicSingleton]
@@ -94,10 +98,10 @@ class TestUseRemote:
         assert proxy.target_cls is BasicSingleton
         assert rpc.calls[0][1] == BasicSingleton.get_remote_id()
 
-    def test_local_execution_methods_registered(self):
+    def test_local_execution_methods_registered(self) -> None:
         """Classes with @local_execution should be tracked by registry."""
         rpc = FakeRPC()
-        LocalMethodSingleton.use_remote(rpc)
+        LocalMethodSingleton.use_remote(cast(Any, rpc))
 
         registry = LocalMethodRegistry.get_instance()
         assert registry.is_local_method(LocalMethodSingleton, "increment")
@@ -106,10 +110,10 @@ class TestUseRemote:
         assert local_impl() == 1
         assert local_impl() == 2  # local state should be preserved per process
 
-    def test_nested_singletons_receive_callers(self):
+    def test_nested_singletons_receive_callers(self) -> None:
         """Type-hinted ProxiedSingleton attributes get caller proxies injected."""
         rpc = FakeRPC()
-        ParentSingleton.use_remote(rpc)
+        ParentSingleton.use_remote(cast(Any, rpc))
 
         parent_proxy = SingletonMetaclass._instances[ParentSingleton]
         assert isinstance(parent_proxy, FakeCaller)
@@ -126,13 +130,13 @@ class TestUseRemote:
 
 
 class TestLocalMethodRegistry:
-    def test_get_local_method_requires_registration(self):
+    def test_get_local_method_requires_registration(self) -> None:
         """Attempting to access unregistered class should raise."""
         registry = LocalMethodRegistry.get_instance()
         with pytest.raises(ValueError):
             registry.get_local_method(BasicSingleton, "ping")
 
-    def test_register_class_initializes_local_instance(self):
+    def test_register_class_initializes_local_instance(self) -> None:
         registry = LocalMethodRegistry.get_instance()
         registry.register_class(LocalMethodSingleton)
         local_impl = registry.get_local_method(LocalMethodSingleton, "increment")

--- a/tests/test_tensor_serializer_signal_cleanup.py
+++ b/tests/test_tensor_serializer_signal_cleanup.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import importlib
 import signal
+from typing import Any
 
 
-def test_signal_cleanup_handler_tolerates_missing_sighup(monkeypatch) -> None:
+def test_signal_cleanup_handler_tolerates_missing_sighup(monkeypatch: Any) -> None:
     import pyisolate._internal.tensor_serializer as tensor_serializer
 
     monkeypatch.setenv("PYISOLATE_SIGNAL_CLEANUP", "1")
@@ -12,7 +13,7 @@ def test_signal_cleanup_handler_tolerates_missing_sighup(monkeypatch) -> None:
 
     installed: list[object] = []
 
-    def fake_signal(sig, _handler):
+    def fake_signal(sig: Any, _handler: Any) -> None:
         installed.append(sig)
 
     monkeypatch.setattr(signal, "signal", fake_signal)

--- a/tests/test_tensor_value_json.py
+++ b/tests/test_tensor_value_json.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from pyisolate._internal.tensor_serializer import _deserialize_json_tensor
+
+
+def test_deserialize_json_tensor_rejects_unknown_dtype_without_torch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unknown TensorValue dtypes should fail fast in torchless workers."""
+
+    def fail_require_torch(context: str) -> None:  # noqa: ARG001
+        raise RuntimeError("torch unavailable")
+
+    monkeypatch.setattr("pyisolate._internal.tensor_serializer.require_torch", fail_require_torch)
+
+    with pytest.raises(ValueError, match="Unsupported TensorValue dtype"):
+        _deserialize_json_tensor(
+            {
+                "dtype": "torch.complex64",
+                "data": [1.0, 2.0],
+                "tensor_size": [2],
+                "requires_grad": False,
+            }
+        )

--- a/tests/test_torch_utils_additional.py
+++ b/tests/test_torch_utils_additional.py
@@ -1,10 +1,11 @@
 from types import SimpleNamespace
+from typing import Any
 
 from pyisolate._internal import torch_utils
 
 
-def test_get_torch_ecosystem_packages_includes_distributions(monkeypatch):
-    def fake_distributions():
+def test_get_torch_ecosystem_packages_includes_distributions(monkeypatch: Any) -> Any:
+    def fake_distributions() -> Any:
         meta = SimpleNamespace(metadata={"Name": "nvidia-cublas"})
         meta2 = SimpleNamespace(metadata={"Name": "torch-hub"})
         return [meta, meta2]
@@ -16,8 +17,8 @@ def test_get_torch_ecosystem_packages_includes_distributions(monkeypatch):
     assert "torch-hub" in pkgs
 
 
-def test_get_torch_ecosystem_packages_handles_exception(monkeypatch):
-    def bad_distributions():
+def test_get_torch_ecosystem_packages_handles_exception(monkeypatch: Any) -> None:
+    def bad_distributions() -> None:
         raise RuntimeError("boom")
 
     torch_utils.get_torch_ecosystem_packages.cache_clear()

--- a/tests/test_uv_sealed_integration.py
+++ b/tests/test_uv_sealed_integration.py
@@ -11,11 +11,13 @@ import subprocess
 import sys
 import uuid
 from pathlib import Path
+from typing import cast
 
 import pytest
 import torch  # noqa: E402
 
 from pyisolate._internal.host import Extension  # noqa: E402
+from pyisolate.config import ExtensionConfig  # noqa: E402
 from pyisolate.sealed import SealedNodeExtension  # noqa: E402
 
 UV_BIN = Path(sys.executable).with_name("uv.exe" if os.name == "nt" else "uv")
@@ -44,24 +46,27 @@ def _host_site_root() -> str:
     return str(Path(sys.executable).resolve().parents[1])
 
 
-def _build_uv_config(fixture_path: Path, run_dir: Path) -> dict:
+def _build_uv_config(fixture_path: Path, run_dir: Path) -> ExtensionConfig:
     # Inlined from fixtures/uv_sealed_worker/pyproject.toml — no TOML parser needed.
-    return {
-        "name": "uv-sealed-worker",
-        "module_path": str(fixture_path),
-        "isolated": True,
-        "dependencies": ["boltons"],
-        "apis": [],
-        "env": {
-            "PYISOLATE_ARTIFACT_DIR": str(run_dir / "artifacts"),
-            "PYISOLATE_SIGNAL_CLEANUP": "1",
+    return cast(
+        ExtensionConfig,
+        {
+            "name": "uv-sealed-worker",
+            "module_path": str(fixture_path),
+            "isolated": True,
+            "dependencies": ["boltons"],
+            "apis": [],
+            "env": {
+                "PYISOLATE_ARTIFACT_DIR": str(run_dir / "artifacts"),
+                "PYISOLATE_SIGNAL_CLEANUP": "1",
+            },
+            "share_torch": False,
+            "share_cuda_ipc": False,
+            "sandbox": {"writable_paths": [str(run_dir / "artifacts")]},
+            "package_manager": "uv",
+            "execution_model": "sealed_worker",
         },
-        "share_torch": False,
-        "share_cuda_ipc": False,
-        "sandbox": {"writable_paths": [str(run_dir / "artifacts")]},
-        "package_manager": "uv",
-        "execution_model": "sealed_worker",
-    }
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Release `pyisolate 0.10.2` from a clean branch cut from `Comfy-Org/main`.

Highlights:
- land runtime and isolation fixes for `0.10.2`
- harden repo and release artifact gates
- align tests and fixtures with the `0.10.2` release delta
- bump package and runtime versioning to `0.10.2`

Verification on clean branch `release/0.10.2` (`84ca6bc08634846cc87a82833e65b8109ca11f55`):
- CI: https://github.com/pollockjj/pyisolate/actions/runs/24309886888
- PyTorch Tests: https://github.com/pollockjj/pyisolate/actions/runs/24309886886
- Windows Tests: https://github.com/pollockjj/pyisolate/actions/runs/24309886889
- Build Wheels: https://github.com/pollockjj/pyisolate/actions/runs/24309886884

Branch shape:
- fresh branch from `upstream/main`
- curated release-only commit stack
- no unrelated `develop` backlog in the PR delta

Prior accepted release evidence from `mydevelopment` issue `#47`:
- local gate: `ruff check pyisolate tests`
- local gate: `ruff format --check pyisolate tests`
- local gate: `mypy pyisolate tests`
- local gate: `pytest -q`
- release artifacts: wheel + sdist, `twine check`, install/import smoke tests

Control plane:
- release issue: https://github.com/pollockjj/mydevelopment/issues/47
